### PR TITLE
Replace lodash modules with lightweight alternatives

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,13 +2,7 @@
 
 const svgTagNames = require('svg-tag-names');
 const flatten = require('arr-flatten');
-
-const omit = (obj, keys) => Object.keys(obj).reduce((newObj, key) => {
-	if (!keys.includes(key)) {
-		newObj[key] = obj[key];
-	}
-	return newObj;
-}, {});
+const omit = require('object.omit');
 
 // Copied from Preact
 const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|ows|mnc|ntw|ine[ch]|zoo|^ord/i;

--- a/index.js
+++ b/index.js
@@ -1,11 +1,7 @@
 'use strict';
 
 const svgTagNames = require('svg-tag-names');
-
-// Source: https://gist.github.com/Integralist/749153aa53fea7168e7e#gistcomment-1457123
-const flatten = list => list.reduce(
-	(a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), []
-);
+const flatten = require('arr-flatten');
 
 const omit = (obj, keys) => Object.keys(obj).reduce((newObj, key) => {
 	if (!keys.includes(key)) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,11 @@
 'use strict';
 
 const svgTagNames = require('svg-tag-names');
-const flatten = require('lodash.flattendeep');
+
+// Source: https://gist.github.com/Integralist/749153aa53fea7168e7e#gistcomment-1457123
+const flatten = list => list.reduce(
+	(a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), []
+);
 
 const omit = (obj, keys) => Object.keys(obj).reduce((newObj, key) => {
 	if (!keys.includes(key)) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,13 @@
 
 const svgTagNames = require('svg-tag-names');
 const flatten = require('lodash.flattendeep');
-const omit = require('lodash.omit');
+
+const omit = (obj, keys) => Object.keys(obj).reduce((newObj, key) => {
+	if (!keys.includes(key)) {
+		newObj[key] = obj[key];
+	}
+	return newObj;
+}, {});
 
 // Copied from Preact
 const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|ows|mnc|ntw|ine[ch]|zoo|^ord/i;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "dom"
   ],
   "dependencies": {
-    "lodash.omit": "^4.5.0",
     "svg-tag-names": "^1.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dom"
   ],
   "dependencies": {
+    "arr-flatten": "^1.0.3",
     "svg-tag-names": "^1.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   ],
   "dependencies": {
     "arr-flatten": "^1.0.3",
+    "object.omit": "^2.0.1",
     "svg-tag-names": "^1.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "dom"
   ],
   "dependencies": {
-    "lodash.flattendeep": "^4.4.0",
     "lodash.omit": "^4.5.0",
     "svg-tag-names": "^1.1.1"
   },


### PR DESCRIPTION
`dom-chef` currently builds to 50.5KB because of Lodash extensive comments and flexibility. Refined GitHub ships dependencies unminified so we get the whole 50K. A bit of a waste, I'd say.

Try:

```sh
$ npm i package-size -g
$ package-size dom-chef . --es6

package   size     minified  gzipped
dom-chef  50.5 kB  9.54 kB   3.48 kB
.         3.21 kB  1.77 kB   736 B
```