### PR TITLE
Drop explicit type casting

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ function h(tagName, attrs) {
 			child = '';
 		}
 
-		return document.createTextNode(String(child));
+		return document.createTextNode(child);
 	});
 
 	return build(tagName, attrs, children);


### PR DESCRIPTION
It's done internally:

<img width="194" alt="screen shot 2017-07-02 at 09 16 52" src="https://user-images.githubusercontent.com/1402241/27766577-59790de4-5f07-11e7-9eac-de6c90bc042d.png">
