### PR TITLE
Use addEventListener instead of the properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ const build = (tagName, attrs, children) => {
 	});
 
 	getEventListeners(attrs).forEach(event => {
-		el[event.name] = event.listener;
+		el.addEventListener(event.name.replace('on', ''), event.listener);
 	});
 
 	const setHTML = attrs.dangerouslySetInnerHTML;

--- a/test.js
+++ b/test.js
@@ -251,16 +251,3 @@ test('attach event listeners', t => {
 	t.is(el.outerHTML, '<a href="#">Download</a>');
 	t.true(handleClick.calledOnce);
 });
-
-test('trigger events for nested elements', t => {
-	const handleClick = spy();
-	const el = (
-		<div>
-			<a href="#" onClick={handleClick}>Download</a>
-		</div>
-	);
-
-	el.firstChild.onclick();
-
-	t.true(handleClick.calledOnce);
-});

--- a/test.js
+++ b/test.js
@@ -244,10 +244,13 @@ test('set html', t => {
 });
 
 test('attach event listeners', t => {
-	const handleClick = spy();
+	spy(EventTarget.prototype, 'addEventListener');
+
+	const handleClick = function () {};
 	const el = <a href="#" onClick={handleClick}>Download</a>;
-	el.onclick();
 
 	t.is(el.outerHTML, '<a href="#">Download</a>');
-	t.true(handleClick.calledOnce);
+
+	t.true(EventTarget.prototype.addEventListener.calledOnce);
+	t.deepEqual(EventTarget.prototype.addEventListener.firstCall.args, ['click', handleClick]);
 });


### PR DESCRIPTION
> [addEventListener] replaces the existing click event listener(s) on the element if there are any. Other events and associated event handlers such as blur (onblur), keypress (onkeypress), and so on behave similarly.
> 
> https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Older_way_to_register_event_listeners