### PR TITLE
Add support for xlink:href

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,11 +77,13 @@ const createElement = tagName => {
 	return document.createElement(tagName);
 };
 
-const setAttribute = (tagName, el, name, value) => {
-	if (isSVG(tagName)) {
-		el.setAttribute(name, value);
+const setAttribute = (el, name, value) => {
+	// Naive support for xlink namespace
+	// Full list: https://github.com/facebook/react/blob/1843f87/src/renderers/dom/shared/SVGDOMPropertyConfig.js#L258-L264
+	if (/^xlink[AHRST]/.test(name)) {
+		el.setAttributeNS('http://www.w3.org/1999/xlink', name, value);
 	} else {
-		el.setAttributeNS(null, name, value);
+		el.setAttribute(name, value);
 	}
 };
 
@@ -90,7 +92,7 @@ const build = (tagName, attrs, children) => {
 
 	const className = attrs.class || attrs.className;
 	if (className) {
-		setAttribute(tagName, el, 'class', classnames(className));
+		setAttribute(el, 'class', classnames(className));
 	}
 
 	getCSSProps(attrs).forEach(prop => {
@@ -98,7 +100,7 @@ const build = (tagName, attrs, children) => {
 	});
 
 	getHTMLProps(attrs).forEach(prop => {
-		setAttribute(tagName, el, prop.name, prop.value);
+		setAttribute(el, prop.name, prop.value);
 	});
 
 	getEventListeners(attrs).forEach(event => {

--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ const build = (tagName, attrs, children) => {
 
 	const className = attrs.class || attrs.className;
 	if (className) {
-		setAttribute(el, 'class', classnames(className));
+		el.className = classnames(className);
 	}
 
 	getCSSProps(attrs).forEach(prop => {

--- a/test.js
+++ b/test.js
@@ -179,6 +179,24 @@ test.serial('render mixed html and svg', t => {
 	t.deepEqual(document.createElementNS.secondCall.args, [xmlns, 'svg']);
 });
 
+test.serial('create svg links with xlink namespace', t => {
+	spy(Element.prototype, 'setAttributeNS');
+
+	const el = (
+		<svg>
+			<text id="text">Test</text>
+			<use xlinkHref="#text"/>
+			<use xlink-invalid-attribute="#text"/>
+		</svg>
+	);
+
+	t.truthy(el);
+	t.true(Element.prototype.setAttributeNS.calledOnce);
+
+	const xmlns = 'http://www.w3.org/1999/xlink';
+	t.deepEqual(Element.prototype.setAttributeNS.firstCall.args, [xmlns, 'xlinkHref', '#text']);
+});
+
 test('assign className', t => {
 	const el = <span className="a b c"/>;
 


### PR DESCRIPTION
```jsx
const use = <use xlinkHref="#stuff">;
```

It's `xlinkHref` instead of `xlink:href` as shown in:

https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#notable-enhancements