### PR TITLE
Restore SVG classes compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ const build = (tagName, attrs, children) => {
 
 	const className = attrs.class || attrs.className;
 	if (className) {
-		setAttribute(tagName, el, 'class', classnames(className));
+		setAttribute(el, 'class', classnames(className));
 	}
 
 	getCSSProps(attrs).forEach(prop => {

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ const build = (tagName, attrs, children) => {
 
 	const className = attrs.class || attrs.className;
 	if (className) {
-		el.className = classnames(className);
+		setAttribute(tagName, el, 'class', classnames(className));
 	}
 
 	getCSSProps(attrs).forEach(prop => {


### PR DESCRIPTION
I was getting this error after updating from v1: 

<img width="654" alt="Uncaught TypeError: Cannot assign to read only property 'className' of object '#<SVGSVGElement>'" src="https://user-images.githubusercontent.com/1402241/31578053-18f2c9c0-b0df-11e7-8853-e6e8c46701a0.png">
