### PR TITLE
One loop to rule them all

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const svgTags = svgTagNames.filter(name => excludeSvgTags.indexOf(name) === -1);
 const isSVG = tagName => svgTags.indexOf(tagName) >= 0;
 
 const setCSSProps = (el, style) => {
-	return Object
+	Object
 		.keys(style)
 		.forEach(name => {
 			let value = style[name];

--- a/index.js
+++ b/index.js
@@ -55,19 +55,19 @@ const setAttribute = (el, name, value) => {
 const build = (tagName, attrs, children) => {
 	const el = createElement(tagName);
 
-	Object.keys(attrs).forEach(attrName => {
-		const attrVal = attrs[attrName];
-		if (attrName === 'class' || attrName === 'className') {
-			setAttribute(el, 'class', classnames(attrVal));
-		} else if (attrName === 'style') {
-			setCSSProps(el, attrVal);
-		} else if (attrName.indexOf('on') === 0) {
-			const eventName = attrName.substr(2).toLowerCase();
-			el.addEventListener(eventName, attrVal);
-		} else if (attrName === 'dangerouslySetInnerHTML') {
-			el.innerHTML = attrVal.__html;
-		} else if (attrName !== 'key') {
-			setAttribute(el, attrName, attrVal);
+	Object.keys(attrs).forEach(name => {
+		const value = attrs[name];
+		if (name === 'class' || name === 'className') {
+			setAttribute(el, 'class', classnames(value));
+		} else if (name === 'style') {
+			setCSSProps(el, value);
+		} else if (name.indexOf('on') === 0) {
+			const eventName = name.substr(2).toLowerCase();
+			el.addEventListener(eventName, value);
+		} else if (name === 'dangerouslySetInnerHTML') {
+			el.innerHTML = value.__html;
+		} else if (name !== 'key') {
+			setAttribute(el, name, value);
 		}
 	});
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 const svgTagNames = require('svg-tag-names');
 const classnames = require('classnames');
 const flatten = require('arr-flatten');
-const omit = require('object.omit');
 
 // Copied from Preact
 const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|ows|mnc|ntw|ine[ch]|zoo|^ord/i;
@@ -21,40 +20,18 @@ const svgTags = svgTagNames.filter(name => excludeSvgTags.indexOf(name) === -1);
 
 const isSVG = tagName => svgTags.indexOf(tagName) >= 0;
 
-const getCSSProps = attrs => {
+const setCSSProps = (el, style) => {
 	return Object
-		.keys(attrs.style || {})
-		.map(name => {
-			let value = attrs.style[name];
+		.keys(style)
+		.forEach(name => {
+			let value = style[name];
 
 			if (typeof value === 'number' && !IS_NON_DIMENSIONAL.test(name)) {
 				value += 'px';
 			}
 
-			return {name, value};
+			el.style.setProperty(name, value);
 		});
-};
-
-const getHTMLProps = attrs => {
-	const allProps = omit(attrs, ['class', 'className', 'style', 'key', 'dangerouslySetInnerHTML']);
-
-	return Object
-		.keys(allProps)
-		.filter(name => name.indexOf('on') !== 0)
-		.map(name => ({
-			name,
-			value: attrs[name]
-		}));
-};
-
-const getEventListeners = attrs => {
-	return Object
-		.keys(attrs)
-		.filter(name => name.indexOf('on') === 0)
-		.map(name => ({
-			name: name.toLowerCase().replace('on', ''),
-			listener: attrs[name]
-		}));
 };
 
 const createElement = tagName => {
@@ -78,27 +55,23 @@ const setAttribute = (el, name, value) => {
 const build = (tagName, attrs, children) => {
 	const el = createElement(tagName);
 
-	const className = attrs.class || attrs.className;
-	if (className) {
-		setAttribute(el, 'class', classnames(className));
-	}
-
-	getCSSProps(attrs).forEach(prop => {
-		el.style.setProperty(prop.name, prop.value);
+	Object.keys(attrs).forEach(attrName => {
+		const attrVal = attrs[attrName];
+		if (attrName === 'class' || attrName === 'className') {
+			setAttribute(el, 'class', classnames(attrVal));
+		} else if (attrName === 'style') {
+			setCSSProps(el, attrVal);
+		} else if (attrName.indexOf('on') === 0) {
+			const eventName = attrName.substr(2).toLowerCase();
+			el.addEventListener(eventName, attrVal);
+		} else if (attrName === 'dangerouslySetInnerHTML') {
+			el.innerHTML = attrVal.__html;
+		} else if (attrName !== 'key') {
+			setAttribute(el, attrName, attrVal);
+		}
 	});
 
-	getHTMLProps(attrs).forEach(prop => {
-		setAttribute(el, prop.name, prop.value);
-	});
-
-	getEventListeners(attrs).forEach(event => {
-		el.addEventListener(event.name, event.listener);
-	});
-
-	const setHTML = attrs.dangerouslySetInnerHTML;
-	if (setHTML && setHTML.__html) {
-		el.innerHTML = setHTML.__html;
-	} else {
+	if (!attrs.dangerouslySetInnerHTML) {
 		children.forEach(child => {
 			el.appendChild(child);
 		});

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "arr-flatten": "^1.0.3",
     "classnames": "^2.2.5",
-    "object.omit": "^2.0.1",
     "svg-tag-names": "^1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
8 fewer loops and 25% fewer dependencies = 15% KB gzip savings and ∞ speed improvements.

We could go the extra mile and use 3 plain `for` loops as well.