### PR TITLE
Add support for document fragments as children of elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function h(tagName, attrs) {
 	const children = document.createDocumentFragment();
 
 	flatten(childrenArgs).forEach(child => {
-		if (child instanceof Element) {
+		if (child instanceof Element || child instanceof DocumentFragment) {
 			children.appendChild(child);
 		} else if (typeof child !== 'boolean' && child !== null) {
 			children.appendChild(document.createTextNode(child));

--- a/test.js
+++ b/test.js
@@ -124,6 +124,18 @@ test('render other elements inside', t => {
 
 	t.is(el.outerHTML, '<div><a href="#first">First</a><a href="#second">Second</a></div>');
 });
+test('render document fragments inside', t => {
+	const template = document.createElement('template');
+	template.innerHTML = 'Hello, <strong>World!</strong> ';
+	const fragment = template.content;
+	const el = (
+		<div>
+			{fragment}
+		</div>
+	);
+
+	t.is(el.outerHTML, '<div>Hello, <strong>World!</strong> </div>');
+});
 
 test.serial('render svg', t => {
 	spy(document, 'createElementNS');

--- a/test.js
+++ b/test.js
@@ -256,7 +256,7 @@ test('attach event listeners', t => {
 	spy(EventTarget.prototype, 'addEventListener');
 
 	const handleClick = function () {};
-	const el = <a href="#" onClick={handleClick}>Download</a>;
+	const el = <a href="#" onClick={handleClick}>Download</a>; // eslint-disable-line react/jsx-no-bind
 
 	t.is(el.outerHTML, '<a href="#">Download</a>');
 


### PR DESCRIPTION
```js
const template = document.createElement('template');
template.innerHTML = 'Hello, <strong>World!</strong>';
<a>{template.content}</a>
```