### PR TITLE
Replace `.setProperty` in favor of `.propertyName = value`

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ const setCSSProps = (el, style) => {
 				value += 'px';
 			}
 
-			el.style.setProperty(name, value);
+			el.style[name] = value;
 		});
 };
 

--- a/test.js
+++ b/test.js
@@ -216,12 +216,13 @@ test('assign styles', t => {
 	const style = {
 		paddingTop: 10,
 		width: 200,
-		height: '200px'
+		height: '200px',
+		fontSize: 12
 	};
 
 	const el = <span style={style}/>;
 
-	t.is(el.outerHTML, '<span style="padding-top: 10px; width: 200px; height: 200px;"></span>');
+	t.is(el.outerHTML, '<span style="padding-top: 10px; width: 200px; height: 200px; font-size: 12px;"></span>');
 });
 
 test('assign other props', t => {

--- a/test.js
+++ b/test.js
@@ -225,6 +225,17 @@ test('assign styles', t => {
 	t.is(el.outerHTML, '<span style="padding-top: 10px; width: 200px; height: 200px; font-size: 12px;"></span>');
 });
 
+test('assign styles with dashed property names', t => {
+	const style = {
+		'padding-top': 10,
+		'font-size': 12
+	};
+
+	const el = <span style={style}/>;
+
+	t.is(el.outerHTML, '<span style="padding-top: 10px; font-size: 12px;"></span>');
+});
+
 test('assign other props', t => {
 	const el = <a href="video.mp4" id="a" download referrerpolicy="no-referrer">Download</a>;
 


### PR DESCRIPTION
`CSSStyleDeclaration.setProperty()` calls accept the hyphen-case of the
CSS property name to be modified. Since we are forwarding the `style`
object of the JSX DOM element directly (which has camelCased names),
styles with more than one word in the property name won't be applied.

The `style.cssPropertyName = 'value';` variant does accept a camelCase
name, so replacing the former with the latter should fix the bug.

Closes #23.