### PR TITLE
Improve pragma-less usage

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,18 @@
+// Adapted from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts
+
+type Key = string | number;
+
+interface Attributes {
+	key?: Key;
+}
+
+declare namespace React {
+	export function createElement<P extends {}>(
+		type: DocumentFragment | string,
+		props?: Attributes & P | null,
+		...children: (Element | DocumentFragment)[]
+	): Element | DocumentFragment;
+
+	export type Fragment = DocumentFragment | Function
+	export type h = typeof createElement
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,7 @@
 // Adapted from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts
 
-type Key = string | number;
-
 interface Attributes {
-	key?: Key;
+	key?: string | number;
 }
 
 declare namespace React {
@@ -13,6 +11,6 @@ declare namespace React {
 		...children: (Element | DocumentFragment)[]
 	): Element | DocumentFragment;
 
-	export type Fragment = DocumentFragment | Function
-	export type h = typeof createElement
+	export type Fragment = DocumentFragment | Function;
+	export type h = typeof createElement;
 }

--- a/index.js
+++ b/index.js
@@ -97,4 +97,26 @@ function h(tagName, attrs) {
 	return build(tagName, attrs || {}, children);
 }
 
-exports.h = h;
+// Improve TypeScript support for DocumentFragment
+// https://github.com/Microsoft/TypeScript/issues/20469
+const React = {
+	createElement: h,
+	Fragment: typeof DocumentFragment === 'function' ? DocumentFragment : () => {}
+};
+
+// Enable support for
+// const React = require('dom-chef')
+module.exports = React;
+
+// Enable support for
+// const {h} = require('dom-chef')
+// import {h} from 'dom-chef'
+module.exports.h = h;
+
+// Enable support for
+// const {React} = require('dom-chef')
+module.exports.React = React;
+
+// Enable support for
+// import React from 'dom-chef'
+module.exports.default = React;

--- a/index.js
+++ b/index.js
@@ -114,9 +114,5 @@ module.exports = React;
 module.exports.h = h;
 
 // Enable support for
-// const {React} = require('dom-chef')
-module.exports.React = React;
-
-// Enable support for
 // import React from 'dom-chef'
 module.exports.default = React;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dom-chef",
-  "version": "3.5.0-0",
+  "version": "3.5.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dom-chef",
-  "version": "3.4.2",
+  "version": "3.5.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dom-chef",
-  "version": "3.4.2",
+  "version": "3.5.0-0",
   "description": "Build DOM elements using JSX automatically",
   "license": "MIT",
   "repository": "vadimdemedes/dom-chef",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dom-chef",
-  "version": "3.5.0-0",
+  "version": "3.5.0-1",
   "description": "Build DOM elements using JSX automatically",
   "license": "MIT",
   "repository": "vadimdemedes/dom-chef",

--- a/react.js
+++ b/react.js
@@ -1,5 +1,6 @@
-// Improve TypeScript support for DocumentFragment
-// https://github.com/Microsoft/TypeScript/issues/20469
+// Only here for v3.4 support
+// TODO: Drop file in v4
+
 exports.React = {
 	createElement: require('.').h,
 	Fragment: DocumentFragment

--- a/readme.md
+++ b/readme.md
@@ -70,7 +70,7 @@ document.body.appendChild(el);
 You can avoid configuring your JSX compiler by just letting it default to `React` and exporting the `React` object:
 
 ```js
-const {React} = require('dom-chef/react'); // Notice the `/react` path
+const React = require('dom-chef');
 ```
 
 This has the advantage of enabling `Fragment` support with the TypeScript compiler, if you're using it compile JSX without Babel. Related issue: https://github.com/Microsoft/TypeScript/issues/20469


### PR DESCRIPTION
When I published v3.4.x patches, I did so in a hurry to avoid breaking existing users, but I just thought of a better solution.

v3.4 worked correctly in browsers but it was breaking node-base environments (like tests) because it expected `global.DocumentFragment` at `require` time.

This PR will use `typeof` before using it and when negative, it will return an empty function. This function is never used. If `dom-chef` is actually run, it will require `DocumentFragment` to be on `global` anyway: 

https://github.com/vadimdemedes/dom-chef/blob/3ada48d0a8504854b70d3f0d43ad6f7c645b8b6a/index.js#L41

---

For this reason, I thought of bringing it back to the main file and enable various and simplified usages:


```js
// Standard until 3.4
const {h} = require('dom-chef')
import {h} from 'dom-chef'
import {React} from 'dom-chef/React'

// Additional in 3.5
const React = require('dom-chef')
import React from 'dom-chef'
```

`React` as a default export enables us to [alias](https://webpack.js.org/configuration/resolve/#resolve-alias) `react` to `dom-chef` even for sub-dependencies (because they usually use `import react from 'react'`)

---

I published this as 3.5.0-0 for testing, but I'd like a review before I do something stupid again 😬

cc @sindresorhus