### PR TITLE
Add support for TextNode children

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ declare namespace React {
 	export function createElement<P extends {}>(
 		type: DocumentFragment | string,
 		props?: Attributes & P | null,
-		...children: (Element | DocumentFragment)[]
+		...children: (Node)[]
 	): Element | DocumentFragment;
 
 	export type Fragment = DocumentFragment | Function;

--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ function h(tagName, attrs) {
 	const children = document.createDocumentFragment();
 
 	flatten(childrenArgs).forEach(child => {
-		if (child instanceof Element || child instanceof DocumentFragment) {
+		if (child instanceof Node) {
 			children.appendChild(child);
 		} else if (typeof child !== 'boolean' && child !== null) {
 			children.appendChild(document.createTextNode(child));

--- a/test.js
+++ b/test.js
@@ -6,6 +6,7 @@ const test = require('ava');
 // `DocumentFragment` global is used/exported right away
 const {window} = new JSDOM('...');
 global.document = window.document;
+global.Node = window.Node;
 global.Element = window.Element;
 global.DocumentFragment = window.DocumentFragment;
 global.EventTarget = window.EventTarget;

--- a/test.js
+++ b/test.js
@@ -98,7 +98,7 @@ test('render div with TextNode child', t => {
 		</div>
 	);
 
-	t.is(el.outerHTML, '<div>Hello/div>');
+	t.is(el.outerHTML, '<div>Hello</div>');
 });
 
 test('skip boolean children', t => {

--- a/test.js
+++ b/test.js
@@ -90,6 +90,16 @@ test('render multiple string children', t => {
 	t.is(el.outerHTML, '<span>hello world</span>');
 });
 
+test('render div with TextNode child', t => {
+	const el = (
+		<div>
+			{document.createTextNode('Hello')}
+		</div>
+	);
+
+	t.is(el.outerHTML, '<div>Hello/div>');
+});
+
 test('skip boolean children', t => {
 	const el = (
 		<span>


### PR DESCRIPTION
For example:

```jsx
const header = document.querySelector('h3');

return <span>{header.firstChild}</span>
```

`.appendChild` supports generic `Node` objects, which includes `Element`, `DocumentFragment` and `TextNode`: https://github.com/Microsoft/TypeScript/blob/9d3707d671592d030386956c9ce39e539b8d0972/src/lib/dom.generated.d.ts#L10431