### PR TITLE
Publish type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "files": [
     "index.js",
+    "index.d.ts",
     "react.js"
   ],
   "keywords": [


### PR DESCRIPTION
Hey,

Currently, type definitions are not published to `npm`. This PR fixes that.

Thanks!