### PR TITLE
Handle boolean attributes correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,8 +69,8 @@ const build = (tagName, attrs, children) => {
 			el.addEventListener(eventName, value);
 		} else if (name === 'dangerouslySetInnerHTML') {
 			el.innerHTML = value.__html;
-		} else if (name !== 'key') {
-			setAttribute(el, name, value);
+		} else if (name !== 'key' && value !== false) {
+			setAttribute(el, name, value === true ? '' : value);
 		}
 	});
 

--- a/test.js
+++ b/test.js
@@ -255,9 +255,15 @@ test('assign styles with dashed property names', t => {
 });
 
 test('assign other props', t => {
-	const el = <a download href="video.mp4" id="a" referrerpolicy="no-referrer">Download</a>;
+	const el = <a href="video.mp4" id="a" referrerpolicy="no-referrer">Download</a>;
 
-	t.is(el.outerHTML, '<a download="true" href="video.mp4" id="a" referrerpolicy="no-referrer">Download</a>');
+	t.is(el.outerHTML, '<a href="video.mp4" id="a" referrerpolicy="no-referrer">Download</a>');
+});
+
+test('assign or skip boolean props', t => {
+	const el = <a download disabled={false} contenteditable={true}>Download</a>;
+
+	t.is(el.outerHTML, '<a download="" contenteditable="">Download</a>');
 });
 
 test('escape props', t => {

--- a/test.js
+++ b/test.js
@@ -261,6 +261,7 @@ test('assign other props', t => {
 });
 
 test('assign or skip boolean props', t => {
+	// eslint-disable-next-line react/jsx-boolean-value
 	const el = <a download disabled={false} contenteditable={true}>Download</a>;
 
 	t.is(el.outerHTML, '<a download="" contenteditable="">Download</a>');


### PR DESCRIPTION
Closes #33 

Add supports for:

```jsx
<a disabled={false}>
// Same as <a>
```

and

```jsx
<a disabled={true}>
// Same as <a disabled> instead of <a disabled="true">
```

If the intended attribute value is `"true"`, then it should be passed as a string. React seems to match this behavior:

https://github.com/facebook/react/blob/b87aabdfe1b7461e7331abb3601d9e6bb27544bc/packages/react-dom/src/client/DOMPropertyOperations.js#L161-L162

Although technically only on a whitelist:

https://github.com/facebook/react/blob/b87aabdfe1b7461e7331abb3601d9e6bb27544bc/packages/react-dom/src/shared/DOMProperty.js#L279-L312