### PR TITLE
Skip `undefined` children

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,9 +15,9 @@ const excludeSvgTags = [
 	'video'
 ];
 
-const svgTags = svgTagNames.filter(name => excludeSvgTags.indexOf(name) === -1);
+const svgTags = svgTagNames.filter(name => !excludeSvgTags.includes(name));
 
-const isSVG = tagName => svgTags.indexOf(tagName) >= 0;
+const isSVG = tagName => svgTags.includes(tagName);
 
 const setCSSProps = (el, style) => {
 	Object
@@ -69,7 +69,7 @@ const build = (tagName, attrs, children) => {
 		} else if (name === 'style') {
 			setCSSProps(el, value);
 		} else if (name.indexOf('on') === 0) {
-			const eventName = name.substr(2).toLowerCase();
+			const eventName = name.slice(2).toLowerCase();
 			el.addEventListener(eventName, value);
 		} else if (name === 'dangerouslySetInnerHTML') {
 			el.innerHTML = value.__html;

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ function h(tagName, attrs) {
 	flatten(childrenArgs).forEach(child => {
 		if (child instanceof Node) {
 			children.appendChild(child);
-		} else if (typeof child !== 'boolean' && child !== null) {
+		} else if (typeof child !== 'boolean' && typeof child !== 'undefined' && child !== null) {
 			children.appendChild(document.createTextNode(child));
 		}
 	});

--- a/test.js
+++ b/test.js
@@ -80,6 +80,7 @@ test('render string child', t => {
 });
 
 test('render multiple string children', t => {
+	/* eslint-disable react/jsx-curly-brace-presence */
 	const el = (
 		<span>
 			{'hello'}
@@ -87,6 +88,7 @@ test('render multiple string children', t => {
 			{'world'}
 		</span>
 	);
+	/* eslint-enable react/jsx-curly-brace-presence */
 
 	t.is(el.outerHTML, '<span>hello world</span>');
 });

--- a/test.js
+++ b/test.js
@@ -118,16 +118,21 @@ test('skip null children', t => {
 	t.is(el.outerHTML, '<span></span>');
 });
 
+test('skip undefined children', t => {
+	const el = <span>{undefined}</span>;
+
+	t.is(el.outerHTML, '<span></span>');
+});
+
 test('render falsey children', t => {
 	const el = (
 		<span>
-			{undefined}
 			{0}
 			{NaN}
 		</span>
 	);
 
-	t.is(el.outerHTML, '<span>undefined0NaN</span>');
+	t.is(el.outerHTML, '<span>0NaN</span>');
 });
 
 test('render other elements inside', t => {


### PR DESCRIPTION
Fixes https://github.com/vadimdemedes/dom-chef/issues/43

I noticed that initially `dom-chef` was expected to appen `undefined` as a string. This PR changes this expectation to align it with React's behavior.