### PR TITLE
Add support for `<Function />`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -74,13 +74,9 @@ const build = (
 ): HTMLElement | SVGElement => {
 	const element = typeof tagName === 'string' ? createElement(tagName) : tagName();
 
-	for (let [name, value] of Object.entries(attrs)) {
+	for (const [name, value] of Object.entries(attrs)) {
 		if (name === 'class' || name === 'className') {
-			if (element.className) {
-				value = element.className + ' ' + value;
-			};
-
-			setAttribute(element, 'class', value as string);
+			setAttribute(element, 'class', (element.getAttribute('class')! + (value as string)).trim());
 		} else if (name === 'style') {
 			setCSSProps(element, value as CSSStyleDeclaration);
 		} else if (name.startsWith('on')) {
@@ -102,7 +98,7 @@ const build = (
 
 const isFragment = (type: DocumentFragmentConstructor | ElementFunction | string): type is DocumentFragmentConstructor => {
 	return type === DocumentFragment;
-}
+};
 
 export const h = (
 	type: DocumentFragmentConstructor | ElementFunction | string,

--- a/index.ts
+++ b/index.ts
@@ -76,7 +76,8 @@ const build = (
 
 	for (const [name, value] of Object.entries(attrs)) {
 		if (name === 'class' || name === 'className') {
-			setAttribute(element, 'class', (element.getAttribute('class')! + (value as string)).trim());
+			const existingClassname = element.getAttribute('class') ?? '';
+			setAttribute(element, 'class', (existingClassname + ' ' + String(value)).trim());
 		} else if (name === 'style') {
 			setCSSProps(element, value as CSSStyleDeclaration);
 		} else if (name.startsWith('on')) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dom-chef",
-  "version": "4.0.0",
+  "version": "4.1.0-0",
   "description": "Build regular DOM elements using JSX",
   "license": "MIT",
   "repository": "vadimdemedes/dom-chef",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@babel/plugin-transform-react-jsx": "^7.9.4",
     "@sindresorhus/tsconfig": "^0.7.0",
     "ava": "^2.4.0",
+    "eslint-plugin-react": "^7.19.0",
     "esm": "^3.2.25",
     "jsdom": "^16.2.1",
     "sinon": "^9.0.1",
@@ -70,17 +71,16 @@
   },
   "xo": {
     "env": "browser",
+    "plugins": [
+      "react"
+    ],
     "rules": {
       "unicorn/prefer-node-append": "off",
       "@typescript-eslint/prefer-readonly-parameter-types": "off",
       "@typescript-eslint/no-empty-function": "off",
       "@typescript-eslint/no-unsafe-member-access": "off",
-      "no-unused-vars": [
-        "error",
-        {
-          "varsIgnorePattern": "React"
-        }
-      ]
+      "react/jsx-uses-vars": "error",
+      "react/jsx-uses-react": "error"
     }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,7 @@ It supports everything you expect from JSX, including:
 - [Event listeners](#inline-event-listeners)
 - [Inline CSS](#inline-styles)
 - [Nested elements](#nested-elements)
+- [Function elements](#use-functions)
 
 If something isn't supported (or doesn't work as well as it does in React) please open an issue!
 
@@ -141,6 +142,32 @@ const el = (
 	</svg>
 );
 ```
+
+### Use functions
+
+If element names start with an uppercase letter, `dom-chef` will consider them as element-returning functions:
+
+```jsx
+function Title() {
+	const title = document.createElement('h1');
+	title.classList.add('Heading');
+	return title;
+}
+
+const el = <Title className="red">La Divina Commedia</Title>;
+// <h1 class="Heading red">La Divina Commedia</h1>
+```
+
+This makes JSX also a great way to apply multiple attributes and content at once:
+
+```jsx
+const BaseIcon = () => document.querySelector('svg.icon').cloneNode(true);
+
+document.body.append(
+	<BaseIcon width="16" title="Starry Day" className="margin-0" />
+);
+```
+
 
 
 ## License

--- a/test.js
+++ b/test.js
@@ -368,6 +368,40 @@ test('div with inner fragment', t => {
 	t.is(element.outerHTML, '<div><h1>heading</h1> text<span>outside fragment</span></div>');
 });
 
+test('element created by function', t => {
+	const Icon = () => document.createElement('i');
+
+	const element = <Icon/>;
+
+	t.is(element.outerHTML, '<i></i>');
+});
+
+test('element created by function with existing children and attributes', t => {
+	const Icon = () => {
+		const icon = document.createElement('i');
+		icon.innerHTML = 'Gummy <span>bears</span>';
+		icon.classList.add('sweet');
+		return icon;
+	}
+
+	const element = <Icon/>;
+
+	t.is(element.outerHTML, '<i class="sweet">Gummy <span>bears</span></i>');
+});
+
+test('element created by function with combined children and attributes', t => {
+	const Icon = () => {
+		const icon = document.createElement('i');
+		icon.innerHTML = 'Gummy <span>bears</span>';
+		icon.classList.add('sweet');
+		return icon;
+	}
+
+	const element = <Icon className="yellow"> and <b>lollipops</b></Icon>;
+
+	t.is(element.outerHTML, '<i class="sweet yellow">Gummy <span>bears</span> and <b>lollipops</b></i>');
+});
+
 function getFragmentHTML(fragment /* : DocumentFragment */) /* : string */ {
 	return [...fragment.childNodes]
 		.map(n => n.outerHTML || n.textContent)

--- a/test.js
+++ b/test.js
@@ -382,7 +382,7 @@ test('element created by function with existing children and attributes', t => {
 		icon.innerHTML = 'Gummy <span>bears</span>';
 		icon.classList.add('sweet');
 		return icon;
-	}
+	};
 
 	const element = <Icon/>;
 
@@ -395,7 +395,7 @@ test('element created by function with combined children and attributes', t => {
 		icon.innerHTML = 'Gummy <span>bears</span>';
 		icon.classList.add('sweet');
 		return icon;
-	}
+	};
 
 	const element = <Icon className="yellow"> and <b>lollipops</b></Icon>;
 


### PR DESCRIPTION
Closes #55 

This introduces a very simple support for element-returning functions. My use case would be using an icon library with DOM-returning functions which I can then customize:

```js
import {BirdIcon} from 'icons';

document.body.append(<BirdIcon width={32} height={32} className="margin-2"/>);
```

## Attribute handling

AFAIK in React `<Component prop={1}>` would pass `{prop: 1}` to `Component`. The component itself will then handle the props.

In `dom-chef's` world this wouldn't make sense props exist solely as attributes on the generated element, _not_ as a JavaScript object. That would be a leaky abstraction.

My resolution is that if one wants `Component` to receive `{prop: 1}` they should not use JSX.

## Class handling

CSS classes are appended to any existing ones, unlike other attributes. This is not overridable.

## Children handling

Children are also appended. This is not overridable.

---

For these we _could_ add custom properties:

```jsx
// Attribute handling
<Component prop={1} chef:get-props />

// Class handling
<BirdIcon className="red" chef:className="replace" />

// Children handling
<Title chef:children="replace">The Lion Peasant</Title>
```

But probably `dom-chef` should not become its own framework.