### PR TITLE
Include TypeScript types for JSX

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -122,6 +122,8 @@ export const h = (
 
 export const Fragment = (typeof DocumentFragment === 'function' ? DocumentFragment : () => {}) as Fragment;
 
+// Improve TypeScript support for DocumentFragment
+// https://github.com/Microsoft/TypeScript/issues/20469
 export default {
 	createElement: h,
 	Fragment

--- a/index.ts
+++ b/index.ts
@@ -14,7 +14,11 @@ type ElementFunction = () => HTMLElement | SVGElement;
 
 declare global {
 	namespace JSX {
-		interface Element extends HTMLElement {}
+		interface Element extends HTMLElement, SVGElement, DocumentFragment {
+			addEventListener: HTMLElement['addEventListener'];
+			removeEventListener: HTMLElement['removeEventListener'];
+			className: HTMLElement['className'];
+		}
 	}
 }
 

--- a/index.ts
+++ b/index.ts
@@ -12,6 +12,12 @@ type Attributes = JSX.IntrinsicElements['div'];
 type DocumentFragmentConstructor = typeof DocumentFragment;
 type ElementFunction = () => HTMLElement | SVGElement;
 
+declare global {
+	namespace JSX {
+		interface Element extends HTMLElement {}
+	}
+}
+
 // Copied from Preact
 const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|ows|mnc|ntw|ine[ch]|zoo|^ord/i;
 

--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,12 @@ declare global {
 	}
 }
 
+interface JSXElementClassDocumentFragment extends DocumentFragment, JSX.ElementClass {}
+interface Fragment {
+	prototype: JSXElementClassDocumentFragment;
+	new (): JSXElementClassDocumentFragment;
+}
+
 // Copied from Preact
 const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|ows|mnc|ntw|ine[ch]|zoo|^ord/i;
 
@@ -114,9 +120,9 @@ export const h = (
 	return element;
 };
 
-// Improve TypeScript support for DocumentFragment
-// https://github.com/Microsoft/TypeScript/issues/20469
+export const Fragment = (typeof DocumentFragment === 'function' ? DocumentFragment : () => {}) as Fragment;
+
 export default {
 	createElement: h,
-	Fragment: typeof DocumentFragment === 'function' ? DocumentFragment : () => {}
+	Fragment
 };

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
 	"type": "module",
 	"main": "index.js",
 	"module": "index.js",
-	"types": "./index.d.ts",
 	"files": [
 		"index.js",
 		"index.d.ts"

--- a/package.json
+++ b/package.json
@@ -42,13 +42,13 @@
     "typescript"
   ],
   "dependencies": {
-    "svg-tag-names": "^2.0.1"
+    "svg-tag-names": "^2.0.1",
+    "@types/react": "^16.9.34"
   },
   "devDependencies": {
     "@ava/babel": "^1.0.1",
     "@babel/plugin-transform-react-jsx": "^7.9.4",
     "@sindresorhus/tsconfig": "^0.7.0",
-    "@types/react": "^16.9.34",
     "ava": "^2.4.0",
     "eslint-plugin-react": "^7.19.0",
     "esm": "^3.2.25",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 	"type": "module",
 	"main": "index.js",
 	"module": "index.js",
+	"types": "./index.d.ts",
 	"files": [
 		"index.js",
 		"index.d.ts"


### PR DESCRIPTION
Fixes #36 

## Add JSX.Element override

adding: 
```ts
declare global {
  namespace JSX {
    interface Element extends HTMLElement {}
  }
}
```
ensures that typescript doesn't complain when you write code like this:
 ```ts
const app = <div>app</div>;
document.body.appendChild(app);
```
## h1 Improve typescript fragment support.
```ts
interface JSXElementClassDocumentFragment extends DocumentFragment, JSX.ElementClass {}
interface Fragment {
  prototype: JSXElementClassDocumentFragment;
  new (): JSXElementClassDocumentFragment;
}
...
export const Fragment = (typeof DocumentFragment === 'function' ? DocumentFragment : () => {}) as Fragment;
```
exports `Fragment` so that you can import it from `dom-chef` and typescript doesn't complain.
now you can use fragments like this:
```tsx
import { h, Fragment } from 'dom-chef';
document.body.appendChild(
  <Fragment>
    <div>2</div>
    <div>1</div>
    <div>2</div>
  </Fragment>
);
```


