### PR TITLE
Pass `defaultProps` to element function

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,7 @@ svgTags.delete('video');
 
 type Attributes = JSX.IntrinsicElements['div'];
 type DocumentFragmentConstructor = typeof DocumentFragment;
-type ElementFunction = () => HTMLElement | SVGElement;
+type ElementFunction = ((props?: any) => HTMLElement | SVGElement) & { defaultProps?: any };
 
 // Copied from Preact
 const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|ows|mnc|ntw|ine[ch]|zoo|^ord/i;
@@ -42,7 +42,7 @@ const create = (type: DocumentFragmentConstructor | ElementFunction | string): H
 		return document.createDocumentFragment();
 	}
 
-	return type();
+	return type(type.defaultProps);
 };
 
 const setAttribute = (element: HTMLElement | SVGElement, name: string, value: string): void => {

--- a/readme.md
+++ b/readme.md
@@ -168,6 +168,21 @@ document.body.append(
 );
 ```
 
+To improve compatibility with React components, `dom-chef` will pass the function's `defaultProps` property to itself (if present). Note that specifying attributes won't override those defaults, but instead set them on the resulting element:
+
+```jsx
+function AlertIcon(props) {
+	return <svg width={props.size} className={props.className} />
+}
+
+AlertIcon.defaultProps = {
+	className: 'icon icon-alert'
+	size: 16,
+}
+
+const el = <AlertIcon className="margin-0" size={32} />;
+// <svg width="16" class="icon icon-alert margin-0" size="32" />
+```
 
 
 ## License


### PR DESCRIPTION
This improves compatibility for simple React Functional Components like [@primer/octicon-react](https://www.unpkg.com/browse/@primer/octicons-react@10.0.0/dist/index.esm.js):

![](https://user-images.githubusercontent.com/202916/84538251-9c717b00-acf1-11ea-966f-bae07e388221.png)