### PR TITLE
Meta: Use `ghat` to update `esm-lint`

### DIFF
--- a/.github/workflows/esm-lint.yml
+++ b/.github/workflows/esm-lint.yml
@@ -1,10 +1,10 @@
-# Copied, adapted and updated from https://github.com/sindresorhus/module-requests/issues/116
+env:
+  IMPORT_TEXT: import React from
+  NPM_MODULE_NAME: dom-chef
+
+# DO NOT EDIT BELOW - use `npx ghat fregante/ghatemplates/esm-lint --exclude jobs.TypeScript`
 
 name: ESM
-
-env:
-  importer: "import React from 'dom-chef'"
-
 on:
   pull_request:
     branches:
@@ -12,7 +12,6 @@ on:
   push:
     branches:
       - master
-
 jobs:
   Pack:
     runs-on: ubuntu-latest
@@ -25,47 +24,42 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: package
-
   Webpack:
     runs-on: ubuntu-latest
     needs: Pack
     steps:
       - uses: actions/download-artifact@v2
       - run: npm install ./artifact
-      - run: echo $importer > index.js
-      - run: webpack index.js
+      - run: echo "$IMPORT_TEXT '$NPM_MODULE_NAME'" > index.js
+      - run: webpack ./index.js
       - run: cat dist/main.js
-
   Parcel:
     runs-on: ubuntu-latest
     needs: Pack
     steps:
       - uses: actions/download-artifact@v2
       - run: npm install ./artifact
-      - run: echo $importer > index.js
+      - run: echo "$IMPORT_TEXT '$NPM_MODULE_NAME'" > index.js
       - run: npx parcel@1 build index.js
       - run: cat dist/index.js
-
   Rollup:
     runs-on: ubuntu-latest
     needs: Pack
     steps:
       - uses: actions/download-artifact@v2
       - run: npm install ./artifact rollup@2 @rollup/plugin-node-resolve
-      - run: echo $importer > index.js
+      - run: echo "$IMPORT_TEXT '$NPM_MODULE_NAME'" > index.js
       - run: npx rollup -p node-resolve index.js
-
   Snowpack:
     runs-on: ubuntu-latest
     needs: Pack
     steps:
       - uses: actions/download-artifact@v2
-      - run: echo '{}' > package.json
-      - run: echo $importer > index.js
+      - run: 'echo ''{}'' > package.json'
+      - run: echo "$IMPORT_TEXT '$NPM_MODULE_NAME'" > index.js
       - run: npm install ./artifact
       - run: npx snowpack@2 build
-      - run: cat build/web_modules/dom-chef.js
-
+      - run: cat build/web_modules/$NPM_MODULE_NAME.js
   Node:
     runs-on: ubuntu-latest
     needs: Pack
@@ -73,8 +67,7 @@ jobs:
       - uses: actions/download-artifact@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '13.x'
-      - run: 'echo ''{"type": "module"}'' > package.json'
-      - run: echo $importer > index.js
+          node-version: 13.x
+      - run: echo "$IMPORT_TEXT '$NPM_MODULE_NAME'" > index.mjs
       - run: npm install ./artifact
-      - run: node index.js
+      - run: node index.mjs

--- a/.github/workflows/esm-lint.yml
+++ b/.github/workflows/esm-lint.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v2
       - run: npm install ./artifact
-      - run: echo "$IMPORT_TEXT '$NPM_MODULE_NAME'" > index.js
+      - run: 'echo "${{ env.IMPORT_TEXT }} ''${{ env.NPM_MODULE_NAME }}''" > index.js'
       - run: webpack ./index.js
       - run: cat dist/main.js
   Parcel:
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v2
       - run: npm install ./artifact
-      - run: echo "$IMPORT_TEXT '$NPM_MODULE_NAME'" > index.js
+      - run: 'echo "${{ env.IMPORT_TEXT }} ''${{ env.NPM_MODULE_NAME }}''" > index.js'
       - run: npx parcel@1 build index.js
       - run: cat dist/index.js
   Rollup:
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v2
       - run: npm install ./artifact rollup@2 @rollup/plugin-node-resolve
-      - run: echo "$IMPORT_TEXT '$NPM_MODULE_NAME'" > index.js
+      - run: 'echo "${{ env.IMPORT_TEXT }} ''${{ env.NPM_MODULE_NAME }}''" > index.js'
       - run: npx rollup -p node-resolve index.js
   Snowpack:
     runs-on: ubuntu-latest
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v2
       - run: 'echo ''{}'' > package.json'
-      - run: echo "$IMPORT_TEXT '$NPM_MODULE_NAME'" > index.js
+      - run: 'echo "${{ env.IMPORT_TEXT }} ''${{ env.NPM_MODULE_NAME }}''" > index.js'
       - run: npm install ./artifact
       - run: npx snowpack@2 build
       - run: cat build/web_modules/$NPM_MODULE_NAME.js
@@ -68,6 +68,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 13.x
-      - run: echo "$IMPORT_TEXT '$NPM_MODULE_NAME'" > index.mjs
+      - run: 'echo "${{ env.IMPORT_TEXT }} ''${{ env.NPM_MODULE_NAME }}''" > index.mjs'
       - run: npm install ./artifact
       - run: node index.mjs


### PR DESCRIPTION
1. Enables Webpack 5 support in linter
2. Starts using [ghat](https://github.com/fregante/ghat) to simplify the sharing/updating of the workflow.

New source: https://github.com/fregante/ghatemplates#esm-lint