### PR TITLE
Pass JSX props to function components instead of directly assigning them to the element

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -2,7 +2,3 @@ declare module 'svg-tag-names' {
 	const SvgTagNames: string[];
 	export default SvgTagNames;
 }
-
-declare namespace JSX {
-	interface Element extends HTMLElement, DocumentFragment {}
-}

--- a/index.ts
+++ b/index.ts
@@ -39,6 +39,12 @@ const isFunctionComponent = (type: any): type is FunctionComponent => {
 	return typeof type === 'function' && type !== DocumentFragment;
 };
 
+const createElement = (type: string): HTMLElement | SVGElement => {
+	return svgTags.has(type) ?
+		document.createElementNS('http://www.w3.org/2000/svg', type) :
+		document.createElement(type);
+};
+
 const setCSSProps = (
 	element: HTMLElement | SVGElement,
 	style: CSSStyleDeclaration
@@ -77,10 +83,10 @@ const setAttribute = (
 };
 
 const setAttributes = (
-	element: Element,
+	element: Element | DocumentFragment,
 	attributes?: Attributes
 ) => {
-	if (!attributes) {
+	if (!attributes || element instanceof DocumentFragment) {
 		return;
 	}
 
@@ -144,20 +150,14 @@ export const h = (
 		return type({...type.defaultProps, ...attributes, children});
 	}
 
-	if (typeof type === 'string') {
-		const element = svgTags.has(type) ?
-			document.createElementNS('http://www.w3.org/2000/svg', type) :
-			document.createElement(type);
+	const node = typeof type === 'string' ?
+		createElement(type) :
+		document.createDocumentFragment();
 
-		addChildren(element, children);
-		setAttributes(element, attributes);
+	addChildren(node, children);
+	setAttributes(node, attributes);
 
-		return element;
-	}
-
-	const fragment = document.createDocumentFragment();
-	addChildren(fragment, children);
-	return fragment;
+	return node;
 };
 
 export const Fragment = (typeof DocumentFragment === 'function' ? DocumentFragment : () => {}) as Fragment;

--- a/index.ts
+++ b/index.ts
@@ -51,37 +51,6 @@ const setCSSProps = (
 	}
 };
 
-const createElementFromString = (
-	tagName: string,
-	attributes: Attributes | undefined,
-	children: Node[]
-): HTMLElement | SVGElement => {
-	const element = svgTags.has(tagName) ?
-		document.createElementNS('http://www.w3.org/2000/svg', tagName) :
-		document.createElement(tagName);
-
-	addChildren(element, children);
-	setAttributes(element, attributes);
-
-	return element;
-};
-
-const createDocumentFragment = (
-	children: Node[]
-): DocumentFragment => {
-	const fragment = document.createDocumentFragment();
-	addChildren(fragment, children);
-	return fragment;
-};
-
-const createElementFromFunction = (
-	constructor: FunctionComponent,
-	props: any,
-	children: Node[]
-): HTMLElement | SVGElement => {
-	return constructor({...constructor.defaultProps, ...props, children});
-};
-
 const setAttribute = (
 	element: HTMLElement | SVGElement,
 	name: string,
@@ -164,7 +133,7 @@ export const h = (
 	...children: Node[]
 ): Element | DocumentFragment => {
 	if (isFunctionComponent(type)) {
-		return createElementFromFunction(type, attributes, children);
+		return type({...type.defaultProps, ...attributes, children});
 	}
 
 	if (children.length === 0 && attributes?.children) {
@@ -172,10 +141,19 @@ export const h = (
 	}
 
 	if (typeof type === 'string') {
-		return createElementFromString(type, attributes, children);
+		const element = svgTags.has(type) ?
+			document.createElementNS('http://www.w3.org/2000/svg', type) :
+			document.createElement(type);
+
+		addChildren(element, children);
+		setAttributes(element, attributes);
+
+		return element;
 	}
 
-	return createDocumentFragment(children);
+	const fragment = document.createDocumentFragment();
+	addChildren(fragment, children);
+	return fragment;
 };
 
 export const Fragment = (typeof DocumentFragment === 'function' ? DocumentFragment : () => {}) as Fragment;

--- a/index.ts
+++ b/index.ts
@@ -9,7 +9,6 @@ svgTags.delete('script');
 svgTags.delete('video');
 
 type Attributes = JSX.IntrinsicElements['div'];
-type DocumentFragmentConstructor = typeof DocumentFragment;
 type FunctionComponent = ((props?: any) => HTMLElement | SVGElement) & {
 	defaultProps?: any;
 };
@@ -33,11 +32,7 @@ interface Fragment {
 // Copied from Preact
 const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|ows|mnc|ntw|ine[ch]|zoo|^ord/i;
 
-const isFragment = (
-	type: DocumentFragmentConstructor | FunctionComponent
-): type is DocumentFragmentConstructor => {
-	return type === DocumentFragment;
-};
+const isFunctionComponent = (type: any): type is FunctionComponent => typeof type === 'function' && type !== DocumentFragment;
 
 const setCSSProps = (
 	element: HTMLElement | SVGElement,
@@ -160,10 +155,14 @@ const addChildren = (
 };
 
 export const h = (
-	type: DocumentFragmentConstructor | FunctionComponent | string,
+	type: typeof DocumentFragment | FunctionComponent | string,
 	attributes?: Attributes,
 	...children: Node[]
 ): Element | DocumentFragment => {
+	if (isFunctionComponent(type)) {
+		return createElementFromFunction(type, attributes, children);
+	}
+
 	if (attributes?.children) {
 		if (Array.isArray(attributes.children) && children.length === 0) {
 			children = attributes.children as Node[];
@@ -177,11 +176,7 @@ export const h = (
 		return createElementFromString(type, attributes, children);
 	}
 
-	if (isFragment(type)) {
-		return createDocumentFragment(children);
-	}
-
-	return createElementFromFunction(type, attributes, children);
+	return createDocumentFragment(children);
 };
 
 export const Fragment = (typeof DocumentFragment === 'function' ? DocumentFragment : () => {}) as Fragment;

--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,8 @@ svgTags.delete('video');
 type Attributes = JSX.IntrinsicElements['div'] & {
 	children?: Node[];
 };
-type FunctionComponent = ((props?: any) => HTMLElement | SVGElement) & {
+
+type FunctionComponent = ((props?: any) => Element | DocumentFragment) & {
 	defaultProps?: any;
 };
 
@@ -34,7 +35,9 @@ interface Fragment {
 // Copied from Preact
 const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|ows|mnc|ntw|ine[ch]|zoo|^ord/i;
 
-const isFunctionComponent = (type: any): type is FunctionComponent => typeof type === 'function' && type !== DocumentFragment;
+const isFunctionComponent = (type: any): type is FunctionComponent => {
+	return typeof type === 'function' && type !== DocumentFragment;
+};
 
 const setCSSProps = (
 	element: HTMLElement | SVGElement,
@@ -52,7 +55,7 @@ const setCSSProps = (
 };
 
 const setAttribute = (
-	element: HTMLElement | SVGElement,
+	element: Element,
 	name: string,
 	value: string
 ): void => {
@@ -74,7 +77,7 @@ const setAttribute = (
 };
 
 const setAttributes = (
-	element: HTMLElement | SVGElement,
+	element: Element,
 	attributes?: Attributes
 ) => {
 	if (!attributes) {
@@ -95,7 +98,7 @@ const setAttributes = (
 				'class',
 				(existingClassname + ' ' + String(value)).trim()
 			);
-		} else if (name === 'style') {
+		} else if (name === 'style' && (element instanceof HTMLElement || element instanceof SVGElement)) {
 			setCSSProps(element, value);
 		} else if (name.startsWith('on')) {
 			const eventName = name.slice(2).toLowerCase().replace(/^-/, '');
@@ -109,7 +112,7 @@ const setAttributes = (
 };
 
 const addChildren = (
-	parent: Element | DocumentFragment,
+	parent: Node,
 	children: Node[]
 ): void => {
 	for (const child of children) {

--- a/index.ts
+++ b/index.ts
@@ -41,10 +41,6 @@ declare global {
 		className: HTMLElement['className'];
 	}
 
-	namespace JSX {
-		interface Element extends HTMLElement, SVGElement, DocumentFragment {}
-	}
-
 	namespace React {
 		// eslint-disable-next-line @typescript-eslint/no-unnecessary-qualifier
 		interface ReactElement<P = any, T extends string | React.JSXElementConstructor<any> = string | React.JSXElementConstructor<any>> extends HTMLElement, SVGElement, DocumentFragment {}

--- a/index.ts
+++ b/index.ts
@@ -39,7 +39,8 @@ const setCSSProps = (
 };
 
 const create = (
-	type: DocumentFragmentConstructor | ElementFunction | string
+	type: DocumentFragmentConstructor | ElementFunction | string,
+	props: any
 ): HTMLElement | SVGElement | DocumentFragment => {
 	if (typeof type === 'string') {
 		if (svgTags.has(type)) {
@@ -53,7 +54,7 @@ const create = (
 		return document.createDocumentFragment();
 	}
 
-	return type(type.defaultProps);
+	return type({...type.defaultProps, ...props});
 };
 
 const setAttribute = (
@@ -102,11 +103,11 @@ export const h = (
 	attributes?: Attributes,
 	...children: Node[]
 ): Element | DocumentFragment => {
-	const element = create(type);
+	const element = create(type, attributes);
 
 	addChildren(element, children);
 
-	if (element instanceof DocumentFragment || !attributes) {
+	if (typeof type === 'function' || !attributes || element instanceof DocumentFragment) {
 		return element;
 	}
 

--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,7 @@ svgTags.delete('video');
 
 type Attributes = JSX.IntrinsicElements['div'];
 type DocumentFragmentConstructor = typeof DocumentFragment;
-type ElementFunction = ((props?: any) => HTMLElement | SVGElement) & {
+type FunctionComponent = ((props?: any) => HTMLElement | SVGElement) & {
 	defaultProps?: any;
 };
 
@@ -34,7 +34,7 @@ interface Fragment {
 const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|ows|mnc|ntw|ine[ch]|zoo|^ord/i;
 
 const isFragment = (
-	type: DocumentFragmentConstructor | ElementFunction
+	type: DocumentFragmentConstructor | FunctionComponent
 ): type is DocumentFragmentConstructor => {
 	return type === DocumentFragment;
 };
@@ -78,7 +78,7 @@ const createDocumentFragment = (
 };
 
 const createElementFromFunction = (
-	constructor: ElementFunction,
+	constructor: FunctionComponent,
 	props: any,
 	children: Node[]
 ): HTMLElement | SVGElement => {
@@ -160,7 +160,7 @@ const addChildren = (
 };
 
 export const h = (
-	type: DocumentFragmentConstructor | ElementFunction | string,
+	type: DocumentFragmentConstructor | FunctionComponent | string,
 	attributes?: Attributes,
 	...children: Node[]
 ): Element | DocumentFragment => {

--- a/index.ts
+++ b/index.ts
@@ -135,12 +135,13 @@ export const h = (
 	attributes?: Attributes,
 	...children: Node[]
 ): Element | DocumentFragment => {
-	if (isFunctionComponent(type)) {
-		return type({...type.defaultProps, ...attributes, children});
+	// The `children` parameter takes precedence over `attributes.children`
+	if (children.length === 0) {
+		children = attributes?.children ?? [];
 	}
 
-	if (children.length === 0 && attributes?.children) {
-		children = attributes.children;
+	if (isFunctionComponent(type)) {
+		return type({...type.defaultProps, ...attributes, children});
 	}
 
 	if (typeof type === 'string') {

--- a/index.ts
+++ b/index.ts
@@ -8,7 +8,9 @@ svgTags.delete('iframe');
 svgTags.delete('script');
 svgTags.delete('video');
 
-type Attributes = JSX.IntrinsicElements['div'];
+type Attributes = JSX.IntrinsicElements['div'] & {
+	children?: Node[];
+};
 type FunctionComponent = ((props?: any) => HTMLElement | SVGElement) & {
 	defaultProps?: any;
 };
@@ -113,6 +115,8 @@ const setAttributes = (
 	for (let [name, value] of Object.entries(attributes)) {
 		if (name === 'htmlFor') {
 			name = 'for';
+		} else if (name === 'children') {
+			continue;
 		}
 
 		if (name === 'class' || name === 'className') {
@@ -163,13 +167,8 @@ export const h = (
 		return createElementFromFunction(type, attributes, children);
 	}
 
-	if (attributes?.children) {
-		if (Array.isArray(attributes.children) && children.length === 0) {
-			children = attributes.children as Node[];
-		}
-
-		attributes = {...attributes};
-		delete attributes.children;
+	if (children.length === 0 && attributes?.children) {
+		children = attributes.children;
 	}
 
 	if (typeof type === 'string') {

--- a/index.ts
+++ b/index.ts
@@ -148,6 +148,15 @@ export const h = (
 	attributes?: Attributes,
 	...children: Node[]
 ): Element | DocumentFragment => {
+	if (attributes?.children) {
+		if (Array.isArray(attributes.children) && children.length === 0) {
+			children = attributes.children as Node[];
+		}
+
+		attributes = {...attributes};
+		delete attributes.children;
+	}
+
 	if (typeof type === 'string') {
 		return createElementFromString(type, attributes, children);
 	}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 	"scripts": {
 		"build": "rollup -p json -p typescript --format esm --dir . index.ts",
 		"prepack": "npm run build",
-		"test": "run-p test:* build",
+		"test": "run-p test:* build --continue-on-error",
 		"pretest:ava": "rollup -p json -p 'typescript={declaration: false, outDir: \"./tests\"}' --format cjs --dir tests tests/index.tsx",
 		"test:ava": "ava",
 		"test:xo": "xo",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"build": "rollup -p json -p typescript --format esm --dir . index.ts",
 		"prepack": "npm run build",
 		"test": "run-p test:* build --continue-on-error",
-		"pretest:ava": "rollup -p json -p 'typescript={declaration: false, outDir: \"./tests\"}' --format cjs --dir tests tests/index.tsx",
+		"pretest:ava": "rollup -p json -p \"typescript={declaration: false, outDir: './tests'}\" --format cjs --dir tests tests/index.tsx",
 		"test:ava": "ava",
 		"test:xo": "xo",
 		"watch": "npm run build -- --watch"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	"scripts": {
 		"build": "rollup -p json -p typescript --format esm --dir . index.ts",
 		"prepack": "npm run build",
-		"pretest": "rollup -p json -p 'typescript={declaration: false, outDir: \"./tests\"}' --format cjs --dir tests tests/index.tsx",
+		"pretest": "rollup -p json -p \"typescript={declaration: false, outDir: './tests'}\" --format cjs --dir tests tests/index.tsx",
 		"test": "ava && xo",
 		"watch": "npm run build -- --watch"
 	},

--- a/readme.md
+++ b/readme.md
@@ -152,38 +152,50 @@ If element names start with an uppercase letter, `dom-chef` will consider them a
 ```jsx
 function Title() {
 	const title = document.createElement('h1');
-	title.classList.add('Heading');
+	title.classList.add('Heading', 'red');
+	title.append('La Divina Commedia');
 	return title;
 }
 
-const el = <Title className="red">La Divina Commedia</Title>;
+const el = <Title/>;
 // <h1 class="Heading red">La Divina Commedia</h1>
 ```
 
-This makes JSX also a great way to apply multiple attributes and content at once:
-
 ```jsx
-const BaseIcon = () => document.querySelector('svg.icon').cloneNode(true);
+function Title(props) {
+	const title = <h1 {...props}></h1>;
+	title.classList.add('red');
+	return title;
+}
 
-document.body.append(
-	<BaseIcon width="16" title="Starry Day" className="margin-0" />
-);
+const el = <Title className="Heading">La Divina Commedia</Title>;
+// <h1 class="Heading red">La Divina Commedia</h1>
 ```
 
-To improve compatibility with React components, `dom-chef` will pass the function's `defaultProps` property to itself (if present). Note that specifying attributes won't override those defaults, but instead set them on the resulting element:
+To improve compatibility with React components, `dom-chef` will pass the function's `defaultProps` property to itself (if present). Note that specifying attributes will override those defaults:
 
 ```jsx
 function AlertIcon(props) {
-	return <svg width={props.size} className={props.className} />
+	return (
+		<svg width={props.size} height={props.size} className={props.className}>
+			{props.children}
+		</svg>
+	);
 }
 
 AlertIcon.defaultProps = {
-	className: 'icon icon-alert'
-	size: 16,
+	className: 'icon icon-alert',
+	size: 16
 }
 
-const el = <AlertIcon className="margin-0" size={32} />;
-// <svg width="16" class="icon icon-alert margin-0" size="32" />
+const el = (
+	<AlertIcon size={32}>
+		<circle cx="16" cy="16" r="16" fill="#000"></circle>
+	</AlertIcon>
+);
+// <svg width="32" height="32" class="icon icon-alert">
+//     <circle cx="16" cy="16" r="16" fill="#000"></circle>
+// </svg>
 ```
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -172,7 +172,7 @@ const el = <Title className="Heading">La Divina Commedia</Title>;
 // <h1 class="Heading red">La Divina Commedia</h1>
 ```
 
-To improve compatibility with React components, `dom-chef` will pass the function's `defaultProps` property to itself (if present). Note that specifying attributes will override those defaults:
+[`defaultProps`](https://medium.com/@pojotorshemi/react-basis-default-props-and-typechecking-with-proptypes-4ddf02d15992) is also supported and will be included as props to the function as you'd expect:
 
 ```jsx
 function AlertIcon(props) {

--- a/tests/_fixtures.js
+++ b/tests/_fixtures.js
@@ -4,5 +4,7 @@ const {window} = new JSDOM('…');
 global.document = window.document;
 global.Node = window.Node;
 global.Element = window.Element;
+global.HTMLElement = window.HTMLElement;
+global.SVGElement = window.SVGElement;
 global.DocumentFragment = window.DocumentFragment;
 global.EventTarget = window.EventTarget;

--- a/tests/index.tsx
+++ b/tests/index.tsx
@@ -526,6 +526,18 @@ test('preset children take precedence over children prop', t => {
 	t.is(presetElement.outerHTML, '<h1>Preset</h1>');
 });
 
+test('children prop takes precedence over empty children list', t => {
+	const Inner = (props: Record<string, any>) => <div {...props}/>;
+	const Outer = (props: Record<string, any>) => <Inner {...props}/>;
+
+	const element = <Outer>Hello, <em>World</em></Outer>;
+
+	t.is(
+		element.outerHTML,
+		'<div>Hello, <em>World</em></div>'
+	);
+});
+
 function getFragmentHTML(fragment: DocumentFragment): string {
 	return [...fragment.childNodes]
 		// @ts-expect-error

--- a/tests/index.tsx
+++ b/tests/index.tsx
@@ -322,7 +322,7 @@ test.failing('assign booleanish false props', t => {
 
 	t.is(
 		element.outerHTML,
-		'<span contenteditable="">a contenteditable="false">Download</a></span>'
+		'<span contenteditable=""><a contenteditable="false">Download</a></span>'
 	);
 	t.is(input.outerHTML, '<textarea spellcheck="false"></textarea>');
 });
@@ -464,6 +464,26 @@ test('element created by function', t => {
 	t.is(element.outerHTML, '<i></i>');
 });
 
+test('element created by function has props', t => {
+	const Container = ({value}: {value: string}) => <div>{value}</div>;
+
+	const element = <Container value="Hello world"/>;
+
+	t.is(element.outerHTML, '<div>Hello world</div>');
+});
+
+test('element created by function has props combined with default props', t => {
+	const Container = ({value, className = ''}: {value: string; className?: string}) => <div className={className}>{value}</div>;
+	Container.defaultProps = {
+		value: 'Goodbye world',
+		className: 'class'
+	};
+
+	const element = <Container value="Hello world"/>;
+
+	t.is(element.outerHTML, '<div class="class">Hello world</div>');
+});
+
 test('element created by function with existing children and attributes', t => {
 	const Icon = () => <i className="sweet">Gummy <span>bears</span></i>;
 
@@ -480,7 +500,7 @@ test('element created by function with combined children and attributes', t => {
 
 	t.is(
 		element.outerHTML,
-		'<i class="sweet yellow">Gummy <span>bears</span> and <b>lollipops</b></i>'
+		'<i class="sweet">Gummy <span>bears</span> and <b>lollipops</b></i>'
 	);
 });
 

--- a/tests/index.tsx
+++ b/tests/index.tsx
@@ -506,7 +506,7 @@ test('element created by function with combined children and attributes', t => {
 
 test('handle children prop as children instead of attributes', t => {
 	const Icon = (props: Record<string, any>) => <i title="icon" {...props}/>;
-	
+
 	const element = <Icon className="yellow">Submarine</Icon>;
 
 	t.is(

--- a/tests/index.tsx
+++ b/tests/index.tsx
@@ -465,7 +465,7 @@ test('element created by function', t => {
 });
 
 test('element created by function has props', t => {
-	const Container = ({value}: {value: string}) => <div>{value}</div>;
+	const Container: React.FC<{value: string}> = ({value}) => <div>{value}</div>;
 
 	const element = <Container value="Hello world"/>;
 
@@ -473,7 +473,7 @@ test('element created by function has props', t => {
 });
 
 test('element created by function has props combined with default props', t => {
-	const Container = ({value, className = ''}: {value: string; className?: string}) => <div className={className}>{value}</div>;
+	const Container: React.FC<{value: string; className?: string}> = ({value, className}) => <div className={className}>{value}</div>;
 	Container.defaultProps = {
 		value: 'Goodbye world',
 		className: 'class'
@@ -493,7 +493,7 @@ test('element created by function with existing children and attributes', t => {
 });
 
 test('element created by function with combined children and attributes', t => {
-	const Icon = ({children}: {children: Node[]}) => <i className="sweet">Gummy <span>bears</span>{children}</i>;
+	const Icon: React.FC = ({children}) => <i className="sweet">Gummy <span>bears</span>{children}</i>;
 
 	// @ts-expect-error
 	const element = <Icon className="yellow"> and <b>lollipops</b></Icon>;
@@ -505,7 +505,7 @@ test('element created by function with combined children and attributes', t => {
 });
 
 test('handle children prop as children instead of attributes', t => {
-	const Icon = (props: Record<string, any>) => <i title="icon" {...props}/>;
+	const Icon: React.FC<{className: string}> = props => <i title="icon" {...props}/>;
 
 	const element = <Icon className="yellow">Submarine</Icon>;
 
@@ -516,8 +516,8 @@ test('handle children prop as children instead of attributes', t => {
 });
 
 test('preset children take precedence over children prop', t => {
-	const Open = (props: Record<string, any>) => <h1 {...props}></h1>;
-	const Preset = (props: Record<string, any>) => <h1 {...props}>Preset</h1>;
+	const Open: React.FC = props => <h1 {...props}></h1>;
+	const Preset: React.FC = props => <h1 {...props}>Preset</h1>;
 
 	const openElement = <Open>Door</Open>;
 	const presetElement = <Preset>Door</Preset>;
@@ -527,8 +527,8 @@ test('preset children take precedence over children prop', t => {
 });
 
 test('children prop takes precedence over empty children list', t => {
-	const Inner = (props: Record<string, any>) => <div {...props}/>;
-	const Outer = (props: Record<string, any>) => <Inner {...props}/>;
+	const Inner: React.FC = props => <div {...props}/>;
+	const Outer: React.FC = props => <Inner {...props}/>;
 
 	const element = <Outer>Hello, <em>World</em></Outer>;
 

--- a/tests/index.tsx
+++ b/tests/index.tsx
@@ -515,6 +515,17 @@ test('handle children prop as children instead of attributes', t => {
 	);
 });
 
+test('preset children take precedence over children prop', t => {
+	const Open = (props: Record<string, any>) => <h1 {...props}></h1>;
+	const Preset = (props: Record<string, any>) => <h1 {...props}>Preset</h1>;
+
+	const openElement = <Open>Door</Open>;
+	const presetElement = <Preset>Door</Preset>;
+
+	t.is(openElement.outerHTML, '<h1>Door</h1>');
+	t.is(presetElement.outerHTML, '<h1>Preset</h1>');
+});
+
 function getFragmentHTML(fragment: DocumentFragment): string {
 	return [...fragment.childNodes]
 		// @ts-expect-error

--- a/tests/index.tsx
+++ b/tests/index.tsx
@@ -493,7 +493,7 @@ test('element created by function with existing children and attributes', t => {
 });
 
 test('element created by function with combined children and attributes', t => {
-	const Icon = () => <i className="sweet">Gummy <span>bears</span></i>;
+	const Icon = ({children}: {children: Node[]}) => <i className="sweet">Gummy <span>bears</span>{children}</i>;
 
 	// @ts-expect-error
 	const element = <Icon className="yellow"> and <b>lollipops</b></Icon>;

--- a/tests/index.tsx
+++ b/tests/index.tsx
@@ -504,6 +504,17 @@ test('element created by function with combined children and attributes', t => {
 	);
 });
 
+test('handle children prop as children instead of attributes', t => {
+	const Icon = (props: Record<string, any>) => <i title="icon" {...props}/>;
+	
+	const element = <Icon className="yellow">Submarine</Icon>;
+
+	t.is(
+		element.outerHTML,
+		'<i title="icon" class="yellow">Submarine</i>'
+	);
+});
+
 function getFragmentHTML(fragment: DocumentFragment): string {
 	return [...fragment.childNodes]
 		// @ts-expect-error


### PR DESCRIPTION
## Description:

`dom-chef` didn't pass props to the element's constructor.

## MWE:

```jsx
function Element({ value }) {
    return <div>{value}</div>;
}
document.body.append(<Element value='Hello world'/>);
```

## Old behavior:
```js
// Uncaught TypeError: (destructured parameter) is undefined
```

## Expected/New behavior:
```html
<div>Hello world</div>
```

## Breaking changes

```jsx
const Element = () => <div/>;

document.body.append(<Element className='foo'/>);
```

Previously, this would produce the following element:

```html
<div class='foo'></div>
```

But that's not how things should be. The correct (and current) output is:

```html
<div></div>
```