### PR TITLE
React-like components

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -202,7 +202,7 @@ export const h = (
 };
 
 export const Fragment = (typeof DocumentFragment === 'function' ? DocumentFragment : () => {}) as Fragment;
-      
+
 export abstract class Component<P = Record<string, any>> {
 	props: P;
 	refs: any;

--- a/index.ts
+++ b/index.ts
@@ -39,7 +39,8 @@ const setCSSProps = (
 };
 
 const create = (
-	type: DocumentFragmentConstructor | ElementFunction | string
+	type: DocumentFragmentConstructor | ElementFunction | string,
+	props: any
 ): HTMLElement | SVGElement | DocumentFragment => {
 	if (typeof type === 'string') {
 		if (svgTags.has(type)) {
@@ -53,7 +54,7 @@ const create = (
 		return document.createDocumentFragment();
 	}
 
-	return type(type.defaultProps);
+	return type({...type.defaultProps, ...props});
 };
 
 const setAttribute = (
@@ -102,11 +103,11 @@ export const h = (
 	attributes?: Attributes,
 	...children: Node[]
 ): Element | DocumentFragment => {
-	const element = create(type);
+	const element = create(type, attributes);
 
 	addChildren(element, children);
 
-	if (element instanceof DocumentFragment || !attributes) {
+	if (typeof type === 'function' || !attributes || element instanceof DocumentFragment) {
 		return element;
 	}
 

--- a/index.ts
+++ b/index.ts
@@ -148,6 +148,15 @@ export const h = (
 	attributes?: Attributes,
 	...children: Node[]
 ): Element | DocumentFragment => {
+	if (attributes?.children) {
+		if (Array.isArray(attributes.children) && children.length === 0) {
+			children = attributes.children as Node[];
+		}
+
+		attributes = {...attributes};
+		delete attributes.children;
+	}
+
 	if (typeof type === 'string') {
 		return createElementFromString(type, attributes, children);
 	}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	"scripts": {
 		"build": "rollup -p json -p typescript --format esm --dir . index.ts",
 		"prepack": "npm run build",
-		"pretest": "rollup -p json -p 'typescript={declaration: false, outDir: \"./tests\"}' --format cjs --dir tests tests/index.tsx",
+		"pretest": "rollup -p json -p \"typescript={declaration: false, outDir: './tests'}\" --format cjs --dir tests tests/index.tsx",
 		"test": "ava && xo",
 		"watch": "npm run build -- --watch"
 	},

--- a/readme.md
+++ b/readme.md
@@ -152,38 +152,50 @@ If element names start with an uppercase letter, `dom-chef` will consider them a
 ```jsx
 function Title() {
 	const title = document.createElement('h1');
-	title.classList.add('Heading');
+	title.classList.add('Heading', 'red');
+	title.append('La Divina Commedia');
 	return title;
 }
 
-const el = <Title className="red">La Divina Commedia</Title>;
+const el = <Title/>;
 // <h1 class="Heading red">La Divina Commedia</h1>
 ```
 
-This makes JSX also a great way to apply multiple attributes and content at once:
-
 ```jsx
-const BaseIcon = () => document.querySelector('svg.icon').cloneNode(true);
+function Title(props) {
+	const title = <h1 {...props}></h1>;
+	title.classList.add('red');
+	return title;
+}
 
-document.body.append(
-	<BaseIcon width="16" title="Starry Day" className="margin-0" />
-);
+const el = <Title className="Heading">La Divina Commedia</Title>;
+// <h1 class="Heading red">La Divina Commedia</h1>
 ```
 
-To improve compatibility with React components, `dom-chef` will pass the function's `defaultProps` property to itself (if present). Note that specifying attributes won't override those defaults, but instead set them on the resulting element:
+To improve compatibility with React components, `dom-chef` will pass the function's `defaultProps` property to itself (if present). Note that specifying attributes will override those defaults:
 
 ```jsx
 function AlertIcon(props) {
-	return <svg width={props.size} className={props.className} />
+	return (
+		<svg width={props.size} height={props.size} className={props.className}>
+			{props.children}
+		</svg>
+	);
 }
 
 AlertIcon.defaultProps = {
-	className: 'icon icon-alert'
-	size: 16,
+	className: 'icon icon-alert',
+	size: 16
 }
 
-const el = <AlertIcon className="margin-0" size={32} />;
-// <svg width="16" class="icon icon-alert margin-0" size="32" />
+const el = (
+	<AlertIcon size={32}>
+		<circle cx="16" cy="16" r="16" fill="#000"></circle>
+	</AlertIcon>
+);
+// <svg width="32" height="32" class="icon icon-alert">
+//     <circle cx="16" cy="16" r="16" fill="#000"></circle>
+// </svg>
 ```
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -198,6 +198,28 @@ const el = (
 // </svg>
 ```
 
+If you want to use inheritance, you can use the familiar React component syntax. Note that `render` function is called once, since `dom-chef` only cooks raw DOM elements, so `dom-chef` components are stateless by definition:
+
+```jsx
+import React from 'dom-chef';
+
+class Button extends React.Component {
+	onClick() {
+		console.log('Button was clicked');
+	}
+
+	render() {
+		return <button {...this.props} onClick={this.onClick}></button>;
+	}
+}
+
+class CoolerButton extends Button {
+	onClick() {
+		console.log('CoolerButton was clicked');
+	}
+}
+```
+
 ## License
 
 MIT © [Vadim Demedes](https://github.com/vadimdemedes)

--- a/tests/index.tsx
+++ b/tests/index.tsx
@@ -2,7 +2,7 @@ import test from 'ava';
 import {spy} from 'sinon';
 
 import './_fixtures';
-import React from '..';
+import React, {Component} from '..';
 
 test('render childless element', t => {
 	const element = <br />;
@@ -524,6 +524,21 @@ test('preset children take precedence over children prop', t => {
 
 	t.is(openElement.outerHTML, '<h1>Door</h1>');
 	t.is(presetElement.outerHTML, '<h1>Preset</h1>');
+});
+
+test('render function will be used if possible', t => {
+	class Icon extends Component {
+		render() {
+			return <i {...this.props}></i>;
+		}
+	}
+
+	const element = <Icon className="Never gonna give you up">Never gonna let you down</Icon>;
+
+	t.is(
+		element.outerHTML,
+		'<i class="Never gonna give you up">Never gonna let you down</i>'
+	);
 });
 
 function getFragmentHTML(fragment: DocumentFragment): string {

--- a/tests/index.tsx
+++ b/tests/index.tsx
@@ -322,7 +322,7 @@ test.failing('assign booleanish false props', t => {
 
 	t.is(
 		element.outerHTML,
-		'<span contenteditable="">a contenteditable="false">Download</a></span>'
+		'<span contenteditable=""><a contenteditable="false">Download</a></span>'
 	);
 	t.is(input.outerHTML, '<textarea spellcheck="false"></textarea>');
 });
@@ -464,6 +464,26 @@ test('element created by function', t => {
 	t.is(element.outerHTML, '<i></i>');
 });
 
+test('element created by function has props', t => {
+	const Container = ({value}: {value: string}) => <div>{value}</div>;
+
+	const element = <Container value="Hello world"/>;
+
+	t.is(element.outerHTML, '<div>Hello world</div>');
+});
+
+test('element created by function has props combined with default props', t => {
+	const Container = ({value, className = ''}: {value: string; className?: string}) => <div className={className}>{value}</div>;
+	Container.defaultProps = {
+		value: 'Goodbye world',
+		className: 'class'
+	};
+
+	const element = <Container value="Hello world"/>;
+
+	t.is(element.outerHTML, '<div class="class">Hello world</div>');
+});
+
 test('element created by function with existing children and attributes', t => {
 	const Icon = () => <i className="sweet">Gummy <span>bears</span></i>;
 
@@ -480,7 +500,7 @@ test('element created by function with combined children and attributes', t => {
 
 	t.is(
 		element.outerHTML,
-		'<i class="sweet yellow">Gummy <span>bears</span> and <b>lollipops</b></i>'
+		'<i class="sweet">Gummy <span>bears</span> and <b>lollipops</b></i>'
 	);
 });
 

--- a/tests/index.tsx
+++ b/tests/index.tsx
@@ -506,7 +506,7 @@ test('element created by function with combined children and attributes', t => {
 
 test('handle children prop as children instead of attributes', t => {
 	const Icon = (props: Record<string, any>) => <i title="icon" {...props}/>;
-	
+
 	const element = <Icon className="yellow">Submarine</Icon>;
 
 	t.is(

--- a/tests/index.tsx
+++ b/tests/index.tsx
@@ -515,6 +515,17 @@ test('handle children prop as children instead of attributes', t => {
 	);
 });
 
+test('preset children take precedence over children prop', t => {
+	const Open = (props: Record<string, any>) => <h1 {...props}></h1>;
+	const Preset = (props: Record<string, any>) => <h1 {...props}>Preset</h1>;
+
+	const openElement = <Open>Door</Open>;
+	const presetElement = <Preset>Door</Preset>;
+
+	t.is(openElement.outerHTML, '<h1>Door</h1>');
+	t.is(presetElement.outerHTML, '<h1>Preset</h1>');
+});
+
 function getFragmentHTML(fragment: DocumentFragment): string {
 	return [...fragment.childNodes]
 		// @ts-expect-error

--- a/tests/index.tsx
+++ b/tests/index.tsx
@@ -493,7 +493,7 @@ test('element created by function with existing children and attributes', t => {
 });
 
 test('element created by function with combined children and attributes', t => {
-	const Icon = () => <i className="sweet">Gummy <span>bears</span></i>;
+	const Icon = ({children}: {children: Node[]}) => <i className="sweet">Gummy <span>bears</span>{children}</i>;
 
 	// @ts-expect-error
 	const element = <Icon className="yellow"> and <b>lollipops</b></Icon>;

--- a/tests/index.tsx
+++ b/tests/index.tsx
@@ -504,6 +504,17 @@ test('element created by function with combined children and attributes', t => {
 	);
 });
 
+test('handle children prop as children instead of attributes', t => {
+	const Icon = (props: Record<string, any>) => <i title="icon" {...props}/>;
+	
+	const element = <Icon className="yellow">Submarine</Icon>;
+
+	t.is(
+		element.outerHTML,
+		'<i title="icon" class="yellow">Submarine</i>'
+	);
+});
+
 function getFragmentHTML(fragment: DocumentFragment): string {
 	return [...fragment.childNodes]
 		// @ts-expect-error


### PR DESCRIPTION
Added support for components that look just like React ones:

```jsx
import React from 'dom-chef';

class Icon extends React.Component {
  render() {
    return <i {...this.props}></i>;
  }
}
```

This is done for component inheritance, as well as for better compatibility with React:

```jsx
import React from 'dom-chef';

class Button extends React.Component {
  onClick() {
    console.log('Click');
  }

  render() {
    return <button {...this.props} onClick={this.onClick}/>;
  }
}

class CoolerButton extends Button {
  render() {
    return (
      <cool-wrapper>
        {super.render()}
      </cool-wrapper>
    );
  }
}
```