### PR TITLE
Add support for booleanish string attributes

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -24,10 +24,10 @@ declare global {
 	}
 }
 
-interface JSXElementClassDocumentFragment extends DocumentFragment, JSX.ElementClass {}
+interface JSXElementClassDocumentFragment extends DocumentFragment, JSX.ElementClass { }
 interface Fragment {
 	prototype: JSXElementClassDocumentFragment;
-	new (): JSXElementClassDocumentFragment;
+	new(): JSXElementClassDocumentFragment;
 }
 
 // Copied from Preact
@@ -113,6 +113,19 @@ const addChildren = (
 	}
 };
 
+const reservedAttrs = new Set([
+	// These attributes allow "false" as a valid value
+	'contentEditable',
+	'draggable',
+	'spellCheck',
+	'value',
+	// SVG specific
+	'autoReverse',
+	'externalResourcesRequired',
+	'focusable',
+	'preserveAlpha'
+]);
+
 export const h = (
 	type: DocumentFragmentConstructor | ElementFunction | string,
 	attributes?: Attributes,
@@ -146,7 +159,7 @@ export const h = (
 			element.addEventListener(eventName, value);
 		} else if (name === 'dangerouslySetInnerHTML' && '__html' in value) {
 			element.innerHTML = value.__html;
-		} else if (name !== 'key' && value !== false) {
+		} else if (name !== 'key' && (reservedAttrs.has(name) || value !== false)) {
 			setAttribute(element, name, value === true ? '' : value);
 		}
 	}

--- a/tests/index.tsx
+++ b/tests/index.tsx
@@ -312,7 +312,7 @@ test('assign or skip boolean props', t => {
 	t.is(link.outerHTML, '<a download="" contenteditable="">Download</a>');
 });
 
-test.failing('assign booleanish false props', t => {
+test('assign booleanish false props', t => {
 	const element = (
 		<span contentEditable>
 			<a contentEditable={false}>Download</a>
@@ -322,7 +322,7 @@ test.failing('assign booleanish false props', t => {
 
 	t.is(
 		element.outerHTML,
-		'<span contenteditable="">a contenteditable="false">Download</a></span>'
+		'<span contenteditable=""><a contenteditable="false">Download</a></span>'
 	);
 	t.is(input.outerHTML, '<textarea spellcheck="false"></textarea>');
 });


### PR DESCRIPTION
Closes #33 

Fixes support for attributes that allow `"false"` values:
```tsx
	<div contentEditable={false}>
```
Generates:

```html
	 <div contenteditable="false"/>
```