### PR TITLE
Add detailed TypeScript compiler config

### DIFF
--- a/.github/workflows/esm-lint.yml
+++ b/.github/workflows/esm-lint.yml
@@ -23,7 +23,7 @@ jobs:
       - run: npm install
       - run: npm run build --if-present
       - run: npm pack --dry-run
-      - run: npm pack --silent 2>/dev/null | xargs -n1 tar -xzf
+      - run: npm pack --silent 2>/dev/null | tail -1 | xargs -n1 tar -xzf
       - uses: actions/upload-artifact@v2
         with:
           path: package

--- a/readme.md
+++ b/readme.md
@@ -28,25 +28,42 @@ $ npm install dom-chef
 
 ## Usage
 
-Make sure to use a JSX transpiler, set JSX [`pragma`](https://babeljs.io/docs/en/next/babel-plugin-transform-react-jsx.html#pragma)
-to `h` and optionally the [`pragmaFrag`](https://babeljs.io/docs/en/next/babel-plugin-transform-react-jsx.html#pragmafrag)
-to `DocumentFragment` [if you need fragment support](https://reactjs.org/blog/2017/11/28/react-v16.2.0-fragment-support.html).
+Make sure to use a JSX transpiler:
+- Babel: set JSX [`pragma`](https://babeljs.io/docs/en/next/babel-plugin-transform-react-jsx.html#pragma)
+  to `h` and optionally the [`pragmaFrag`](https://babeljs.io/docs/en/next/babel-plugin-transform-react-jsx.html#pragmafrag)
+  to `DocumentFragment` [if you need fragment support](https://reactjs.org/blog/2017/11/28/react-v16.2.0-fragment-support.html).
+  
+  ```js
+  // babel.config.js
+  
+  const plugins = [
+  	[
+  		'@babel/plugin-transform-react-jsx',
+  		{
+  			pragma: 'h',
+  			pragmaFrag: 'DocumentFragment',
+  		},
+  	],
+  ];
+  
+  // ...
+  ```
 
-```js
-// babel.config.js
+- TypeScript compiler: set [`jsxFactory`](https://www.typescriptlang.org/tsconfig#jsxFactory)
+  to `h` and optionally [`jsxFragmentFactory`](https://www.typescriptlang.org/tsconfig#jsxFragmentFactory)
+  to `DocumentFragment` [if you need fragment support](https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#custom-jsx-factories).
 
-const plugins = [
-	[
-		'@babel/plugin-transform-react-jsx',
-		{
-			pragma: 'h',
-			pragmaFrag: 'DocumentFragment',
-		},
-	],
-];
+  ```jsonc
+  // tsconfig.json
 
-// ...
-```
+  {
+    "compilerOptions": {
+      "jsxFactory": "h",
+      "jsxFragmentFactory": "DocumentFragment"
+      // ...
+    }
+  }
+  ```
 
 ```jsx
 import {h} from 'dom-chef';
@@ -72,12 +89,6 @@ You can avoid configuring your JSX compiler by just letting it default to `React
 
 ```js
 import React from 'dom-chef';
-```
-
-This has the advantage of enabling `Fragment` support with the TypeScript compiler, if you're using it compile JSX without Babel. Related issue: https://github.com/Microsoft/TypeScript/issues/20469
-
-```
-TS17016: JSX fragment is not supported when using --jsxFactory
 ```
 
 ## Recipes

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@ $ npm install dom-chef
 ## Usage
 
 Make sure to use a JSX transpiler:
+
 - Babel: set JSX [`pragma`](https://babeljs.io/docs/en/next/babel-plugin-transform-react-jsx.html#pragma)
   to `h` and optionally the [`pragmaFrag`](https://babeljs.io/docs/en/next/babel-plugin-transform-react-jsx.html#pragmafrag)
   to `DocumentFragment` [if you need fragment support](https://reactjs.org/blog/2017/11/28/react-v16.2.0-fragment-support.html).

--- a/readme.md
+++ b/readme.md
@@ -34,14 +34,14 @@ Make sure to use a JSX transpiler (e.g. [Babel](#babel), [TypeScript compiler](#
 import {h} from 'dom-chef';
 
 const handleClick = e => {
-	// <a> was clicked
+	// <button> was clicked
 };
 
 const el = (
-	<div class="header">
-		<a href="#" class="link" onClick={handleClick}>
+	<div className="header">
+		<button className="btn-link" onClick={handleClick}>
 			Download
-		</a>
+		</button>
 	</div>
 );
 

--- a/readme.md
+++ b/readme.md
@@ -30,9 +30,9 @@ $ npm install dom-chef
 
 Make sure to use a JSX transpiler:
 
-- Babel: set JSX [`pragma`](https://babeljs.io/docs/en/next/babel-plugin-transform-react-jsx.html#pragma)
-  to `h` and optionally the [`pragmaFrag`](https://babeljs.io/docs/en/next/babel-plugin-transform-react-jsx.html#pragmafrag)
-  to `DocumentFragment` [if you need fragment support](https://reactjs.org/blog/2017/11/28/react-v16.2.0-fragment-support.html).
+- Babel: set JSX [`pragma`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx.html#pragma)
+  to `h` and optionally the [`pragmaFrag`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx.html#pragmafrag)
+  to `DocumentFragment` [if you need fragment support](https://reactjs.org/docs/fragments.html).
   
   ```js
   // babel.config.js
@@ -52,7 +52,7 @@ Make sure to use a JSX transpiler:
 
 - TypeScript compiler: set [`jsxFactory`](https://www.typescriptlang.org/tsconfig#jsxFactory)
   to `h` and optionally [`jsxFragmentFactory`](https://www.typescriptlang.org/tsconfig#jsxFragmentFactory)
-  to `DocumentFragment` [if you need fragment support](https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#custom-jsx-factories).
+  to `DocumentFragment` [if you need fragment support](https://reactjs.org/docs/fragments.html).
 
   ```jsonc
   // tsconfig.json

--- a/readme.md
+++ b/readme.md
@@ -28,43 +28,7 @@ $ npm install dom-chef
 
 ## Usage
 
-Make sure to use a JSX transpiler:
-
-- Babel: set JSX [`pragma`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx.html#pragma)
-  to `h` and optionally the [`pragmaFrag`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx.html#pragmafrag)
-  to `DocumentFragment` [if you need fragment support](https://reactjs.org/docs/fragments.html).
-  
-  ```js
-  // babel.config.js
-  
-  const plugins = [
-  	[
-  		'@babel/plugin-transform-react-jsx',
-  		{
-  			pragma: 'h',
-  			pragmaFrag: 'DocumentFragment',
-  		},
-  	],
-  ];
-  
-  // ...
-  ```
-
-- TypeScript compiler: set [`jsxFactory`](https://www.typescriptlang.org/tsconfig#jsxFactory)
-  to `h` and optionally [`jsxFragmentFactory`](https://www.typescriptlang.org/tsconfig#jsxFragmentFactory)
-  to `DocumentFragment` [if you need fragment support](https://reactjs.org/docs/fragments.html).
-
-  ```jsonc
-  // tsconfig.json
-
-  {
-    "compilerOptions": {
-      "jsxFactory": "h",
-      "jsxFragmentFactory": "DocumentFragment"
-      // ...
-    }
-  }
-  ```
+Make sure to use a JSX transpiler (e.g. [Babel](#babel), [TypeScript compiler](#typescript-compiler), [esbuild](https://esbuild.github.io/content-types/#using-jsx-without-react), you only need one of them):
 
 ```jsx
 import {h} from 'dom-chef';
@@ -82,6 +46,46 @@ const el = (
 );
 
 document.body.appendChild(el);
+```
+
+### Babel
+
+Set JSX [`pragma`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx.html#pragma)
+to `h` and optionally the [`pragmaFrag`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx.html#pragmafrag)
+to `DocumentFragment` [if you need fragment support](https://reactjs.org/docs/fragments.html).
+  
+```js
+// babel.config.js
+  
+const plugins = [
+	[
+		'@babel/plugin-transform-react-jsx',
+		{
+			pragma: 'h',
+			pragmaFrag: 'DocumentFragment',
+		},
+	],
+];
+
+// ...
+```
+
+### TypeScript compiler
+
+Set [`jsxFactory`](https://www.typescriptlang.org/tsconfig#jsxFactory)
+to `h` and optionally [`jsxFragmentFactory`](https://www.typescriptlang.org/tsconfig#jsxFragmentFactory)
+to `DocumentFragment` [if you need fragment support](https://reactjs.org/docs/fragments.html).
+
+```jsonc
+// tsconfig.json
+
+{
+	"compilerOptions": {
+		"jsxFactory": "h",
+		"jsxFragmentFactory": "DocumentFragment"
+		// ...
+	}
+}
 ```
 
 ### Alternative usage

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ $ npm install dom-chef
 
 ## Usage
 
-Make sure to use a JSX transpiler (e.g. [Babel](#babel), [TypeScript compiler](#typescript-compiler), [esbuild](https://esbuild.github.io/content-types/#using-jsx-without-react), you only need one of them):
+Make sure to use a JSX transpiler (e.g. [Babel](#babel), [TypeScript compiler](#typescript-compiler), [esbuild](https://esbuild.github.io/content-types/#using-jsx-without-react), you only need one of them).
 
 ```jsx
 import {h} from 'dom-chef';

--- a/readme.md
+++ b/readme.md
@@ -50,9 +50,7 @@ document.body.appendChild(el);
 
 ### Babel
 
-Set JSX [`pragma`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx.html#pragma)
-to `h` and optionally the [`pragmaFrag`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx.html#pragmafrag)
-to `DocumentFragment` [if you need fragment support](https://reactjs.org/docs/fragments.html).
+`pragma` and `pragmaFrag` must be configured this way. More information on [Babel’s documentation](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx.html#pragma).
   
 ```js
 // babel.config.js
@@ -72,9 +70,8 @@ const plugins = [
 
 ### TypeScript compiler
 
-Set [`jsxFactory`](https://www.typescriptlang.org/tsconfig#jsxFactory)
-to `h` and optionally [`jsxFragmentFactory`](https://www.typescriptlang.org/tsconfig#jsxFragmentFactory)
-to `DocumentFragment` [if you need fragment support](https://reactjs.org/docs/fragments.html).
+`jsxFactory` and `jsxFragmentFactory` must be configured this way. More information on [TypeScripts’s documentation](https://www.typescriptlang.org/tsconfig#jsxFactory).
+
 
 ```jsonc
 // tsconfig.json
@@ -83,7 +80,6 @@ to `DocumentFragment` [if you need fragment support](https://reactjs.org/docs/fr
 	"compilerOptions": {
 		"jsxFactory": "h",
 		"jsxFragmentFactory": "DocumentFragment"
-		// ...
 	}
 }
 ```


### PR DESCRIPTION
Initially I just want to correct a typo:

```diff
- This has the advantage of enabling `Fragment` support with the TypeScript compiler, if you're using it compile JSX without Babel. Related issue: https://github.com/Microsoft/TypeScript/issues/20469
+ This has the advantage of enabling `Fragment` support with the TypeScript compiler, if you're using it to compile JSX without Babel. Related issue: https://github.com/Microsoft/TypeScript/issues/20469
```

Then I realized that piece of info is outdated, so I added a extra section for detailed TypeScript compiler config one may need.