### PR TITLE
Add minified build without SVG support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 index.js
 index.d.ts
+!/min/index.d.ts

--- a/index.ts
+++ b/index.ts
@@ -1,12 +1,16 @@
 import svgTagNames from 'svg-tag-names';
 
-const svgTags = new Set(svgTagNames);
-svgTags.delete('a');
-svgTags.delete('audio');
-svgTags.delete('canvas');
-svgTags.delete('iframe');
-svgTags.delete('script');
-svgTags.delete('video');
+declare const __FULL_BUILD__: boolean;
+
+const svgTags = new Set(__FULL_BUILD__ ? svgTagNames : null);
+if (__FULL_BUILD__) {
+	svgTags.delete('a');
+	svgTags.delete('audio');
+	svgTags.delete('canvas');
+	svgTags.delete('iframe');
+	svgTags.delete('script');
+	svgTags.delete('video');
+}
 
 type Attributes = JSX.IntrinsicElements['div'];
 type DocumentFragmentConstructor = typeof DocumentFragment;
@@ -58,7 +62,7 @@ const create = (
 	type: DocumentFragmentConstructor | ElementFunction | string
 ): HTMLElement | SVGElement | DocumentFragment => {
 	if (typeof type === 'string') {
-		if (svgTags.has(type)) {
+		if (__FULL_BUILD__ && svgTags.has(type)) {
 			return document.createElementNS('http://www.w3.org/2000/svg', type);
 		}
 

--- a/index.ts
+++ b/index.ts
@@ -159,7 +159,7 @@ export const h = (
 	return element;
 };
 
-export const Fragment = (typeof DocumentFragment === 'function' ? DocumentFragment : () => {}) as Fragment;
+export const Fragment = DocumentFragment as Fragment;
 
 // Improve TypeScript support for DocumentFragment
 // https://github.com/Microsoft/TypeScript/issues/20469

--- a/index.ts
+++ b/index.ts
@@ -35,7 +35,8 @@ interface Fragment {
 }
 
 // Copied from Preact
-const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|ows|mnc|ntw|ine[ch]|zoo|^ord/i;
+// https://github.com/preactjs/preact/blob/1bbd687c13c1fd16f0d6393e79ea6232f55fbec4/src/constants.js#L3
+const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i;
 
 const isFragment = (
 	type: DocumentFragmentConstructor | ElementFunction

--- a/index.ts
+++ b/index.ts
@@ -87,7 +87,7 @@ const setAttribute = (
 
 	// Naive support for xlink namespace
 	// Full list: https://github.com/facebook/react/blob/1843f87/src/renderers/dom/shared/SVGDOMPropertyConfig.js#L258-L264
-	if (/^xlink[AHRST]/.test(name)) {
+	if (__FULL_BUILD__ && /^xlink[AHRST]/.test(name)) {
 		element.setAttributeNS(
 			'http://www.w3.org/1999/xlink',
 			name.replace('xlink', 'xlink:').toLowerCase(),

--- a/min/index.d.ts
+++ b/min/index.d.ts
@@ -1,0 +1,1 @@
+export * from '..';

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 	"files": [
 		"index.js",
 		"index.d.ts",
-    "min"
+		"min"
 	],
 	"scripts": {
 		"build": "rollup -p replace='{__FULL_BUILD__: true}' -p json -p typescript --format esm --dir . index.ts",

--- a/package.json
+++ b/package.json
@@ -34,13 +34,15 @@
 	"types": "index.js",
 	"files": [
 		"index.js",
-		"index.d.ts"
+		"index.d.ts",
+    "min"
 	],
 	"scripts": {
-		"build": "rollup -p json -p typescript --format esm --dir . index.ts",
-		"prepack": "npm run build",
+		"build": "rollup -p replace='{__FULL_BUILD__: true}' -p json -p typescript --format esm --dir . index.ts",
+		"build:min": "rollup -p replace='{__FULL_BUILD__: false}' -p json -p typescript --format esm --file min/index.js index.ts",
+		"prepack": "npm run build && npm run build:min",
 		"test": "run-p test:* build",
-		"pretest:ava": "rollup -p json -p 'typescript={declaration: false, outDir: \"./tests\"}' --format cjs --dir tests tests/index.tsx",
+		"pretest:ava": "rollup -p replace='{__FULL_BUILD__: true}' -p json -p 'typescript={declaration: false, outDir: \"./tests\"}' --format cjs --dir tests tests/index.tsx",
 		"test:ava": "ava",
 		"test:xo": "xo",
 		"watch": "npm run build -- --watch"
@@ -67,6 +69,7 @@
 	},
 	"devDependencies": {
 		"@rollup/plugin-json": "^4.1.0",
+		"@rollup/plugin-replace": "^4.0.0",
 		"@rollup/plugin-typescript": "^8.2.0",
 		"@sindresorhus/tsconfig": "^0.9.0",
 		"@types/sinon": "^9.0.11",

--- a/readme.md
+++ b/readme.md
@@ -157,6 +157,8 @@ const el = (
 );
 ```
 
+If you do not need SVG support, you can import from `dom-chef/min` for a smaller build.
+
 ### Use functions
 
 If element names start with an uppercase letter, `dom-chef` will consider them as element-returning functions:


### PR DESCRIPTION
Inspired by [`jsx-dom`](https://github.com/proteriax/jsx-dom#svg-and-namespaces), this adds a minified `dom-chef/min` build (name may change) that doesn't have SVG support.