### PR TITLE
Add UMD build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 index.js
 index.d.ts
+umd.js

--- a/package.json
+++ b/package.json
@@ -35,11 +35,12 @@
 	"types": "index.d.ts",
 	"files": [
 		"index.js",
-		"index.d.ts"
+		"index.d.ts",
+		"umd.js"
 	],
 	"scripts": {
-		"build": "tsc",
-		"prepack": "tsc --sourceMap false",
+		"build": "tsc && rollup -c",
+		"prepack": "tsc --sourceMap false && rollup -c",
 		"pretest": "npm run build",
 		"test": "xo && ava",
 		"watch": "npm run build -- --watch"
@@ -70,12 +71,16 @@
 		"svg-tag-names": "^3.0.1"
 	},
 	"devDependencies": {
+		"@rollup/plugin-node-resolve": "^16.0.1",
+		"@rollup/plugin-typescript": "^12.1.4",
 		"@sindresorhus/tsconfig": "^2.0.0",
 		"@types/sinon": "^10.0.11",
 		"ava": "^4.1.0",
 		"eslint-plugin-react": "^7.29.4",
 		"jsdom": "^19.0.0",
+		"rollup": "^4.46.2",
 		"sinon": "^13.0.1",
+		"tslib": "^2.8.1",
 		"typescript": "^4.6.2",
 		"xo": "^0.48.0"
 	}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,32 @@
+import typescript from "@rollup/plugin-typescript"
+import nodeResolve from "@rollup/plugin-node-resolve"
+import path from "node:path"
+// @ts-check
+
+const nodeModulesDir = path.join(process.cwd(), "node_modules");
+
+/** @type {import("rollup").RollupOptions} */
+export default {
+    input: "./index.ts",
+    output: {
+        name: "DOMChef",
+        file: "./umd.js",
+        format: "umd",
+        exports: "named",
+    },
+    plugins: [
+        typescript({
+            declaration: false,
+        }),
+        nodeResolve(),
+        {
+            name: "add-region-to-third-party-libraries",
+            transform(code, id) {
+                if (!id.startsWith(nodeModulesDir)) {
+                    return code;
+                }
+                return "//#region node_modules" + id.slice(nodeModulesDir.length) + "\n" + code + "\n//#endregion"
+            }
+        },
+    ],
+}


### PR DESCRIPTION
I want to use this library in my written UserScript (just in case if you don't know: https://en.wikipedia.org/wiki/Userscript ), but because of `svg-tag-names` dependencies, this library is little a bit noisy if it is bundled to one JS file that meant to read(audit) by humans.

so I decided to add UMD build for library, for import from UserScript with `@require` (because any UserScript loader doesn't have a ESM support at this time).

with this patch, `dom-chef` now have a `umd.js`, and if it is loaded & evaluted, global object now have a `DOMChef` property and you can use it like `DOMChef.h(...)`.
